### PR TITLE
[rojak-pantau] Rojak memantau detikcom

### DIFF
--- a/rojak-pantau/README.md
+++ b/rojak-pantau/README.md
@@ -1,0 +1,27 @@
+# rojak-pantau
+
+Kita menggunakan [Scrapy](https://doc.scrapy.org) untuk dasar `rojak-pantau`.
+Hal ini dikarenakan beberapa pertimbangan yang telah kita diskusikan
+antara lain:
+
+1. Cocok untuk tim. Setiap anggota tim yang mau menambah media tinggal melakukan
+   penambahan dan perubahan sedikit pada source code.
+2. Mudah di deploy
+3. Lengkapnya dokumentasi
+
+## Setup
+
+    sh install_dependencies.sh
+    scrapy crawl detikcom # untuk jalanin rojak-pantau-detik
+
+## Cara penambahan media baru
+
+Untuk penambahan media baru tinggal copy file `rojak_pantau/spider/detikcom.py`
+lalu mengubah nama file dan class sesuai nama media.
+
+Lalu tinggal memodifikasi `name`, `start_urls`, method `parse` dan
+method `parse_news`
+
+## Resources
+
+* [Scrapy 1.2 documentation](https://doc.scrapy.org/en/latest/index.html)

--- a/rojak-pantau/rojak_pantau/items.py
+++ b/rojak-pantau/rojak_pantau/items.py
@@ -7,8 +7,11 @@
 
 import scrapy
 
+class News(scrapy.Item):
+    url = scrapy.Field()
+    title = scrapy.Field()
+    author_name = scrapy.Field()
+    raw_content = scrapy.Field()
+    published_at = scrapy.Field()
+    media_id = scrapy.Field()
 
-class RojakPantauItem(scrapy.Item):
-    # define the fields for your item here like:
-    # name = scrapy.Field()
-    pass

--- a/rojak-pantau/rojak_pantau/pipelines.py
+++ b/rojak-pantau/rojak_pantau/pipelines.py
@@ -15,7 +15,6 @@ class SaveToMySQL(object):
     '''
 
     def process_item(self, item, spider):
-        print '==DEBUG: test save to mysql pipeline'
         url = item.get('url')
         title = item.get('title')
         author_name = item.get('author_name')

--- a/rojak-pantau/rojak_pantau/pipelines.py
+++ b/rojak-pantau/rojak_pantau/pipelines.py
@@ -4,8 +4,34 @@
 #
 # Don't forget to add your pipeline to the ITEM_PIPELINES setting
 # See: http://doc.scrapy.org/en/latest/topics/item-pipeline.html
+import MySQLdb as mysql
+from scrapy.exceptions import CloseSpider
 
+class SaveToMySQL(object):
+    sql_insert_news = '''
+        INSERT INTO `news`(`media_id`, `title`, `raw_content`,
+            `url`, `author_name`, `published_at`)
+        VALUES (%s, %s, %s, %s, %s, %s);
+    '''
 
-class RojakPantauPipeline(object):
     def process_item(self, item, spider):
+        print '==DEBUG: test save to mysql pipeline'
+        url = item.get('url')
+        title = item.get('title')
+        author_name = item.get('author_name')
+        raw_content = item.get('raw_content')
+        published_at = item.get('published_at')
+
+        # Insert to the database
+        try:
+            spider.cursor.execute(self.sql_insert_news, [spider.media['id'],
+                title, raw_content, url, author_name, published_at])
+            spider.db.commit()
+        except mysql.Error as err:
+            spider.db.rollback()
+            error_msg = '{}: Unable to save news: {}'.format(
+                spider.name, err)
+            spider.slack.chat.post_message('#rojak-pantau-errors', error_msg,
+                as_user=True)
+
         return item

--- a/rojak-pantau/rojak_pantau/settings.py
+++ b/rojak-pantau/rojak_pantau/settings.py
@@ -61,9 +61,9 @@ ROBOTSTXT_OBEY = True
 
 # Configure item pipelines
 # See http://scrapy.readthedocs.org/en/latest/topics/item-pipeline.html
-#ITEM_PIPELINES = {
-#    'rojak_pantau.pipelines.SomePipeline': 300,
-#}
+ITEM_PIPELINES = {
+    'rojak_pantau.pipelines.SaveToMySQL': 300,
+}
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See http://doc.scrapy.org/en/latest/topics/autothrottle.html

--- a/rojak-pantau/rojak_pantau/spiders/detikcom.py
+++ b/rojak-pantau/rojak_pantau/spiders/detikcom.py
@@ -3,22 +3,25 @@ import scrapy
 import MySQLdb as mysql
 import os
 from datetime import datetime
-from scrapy.exceptions import CloseSpider
+from scrapy.exceptions import CloseSpider, NotConfigured
+from scrapy import signals
+from rojak_pantau.items import News
+from scrapy.loader import ItemLoader
+from slacker import Slacker
 
 ROJAK_DB_HOST = os.getenv('ROJAK_DB_HOST', 'localhost')
 ROJAK_DB_PORT = int(os.getenv('ROJAK_DB_PORT', 3306))
 ROJAK_DB_USER = os.getenv('ROJAK_DB_USER', 'root')
 ROJAK_DB_PASS = os.getenv('ROJAK_DB_PASS', 'rojak')
 ROJAK_DB_NAME = os.getenv('ROJAK_DB_NAME', 'rojak_database')
+ROJAK_SLACK_TOKEN = os.getenv('ROJAK_SLACK_TOKEN', '')
 
 sql_get_media = '''
 SELECT id,last_scraped_at FROM media WHERE name=%s;
 '''
 
-sql_insert_news = '''
-INSERT INTO `news`(`media_id`, `title`, `raw_content`,
-    `url`, `author_name`, `published_at`)
-VALUES (%s, %s, %s, %s, %s, %s);
+sql_update_media = '''
+UPDATE `media` SET last_scraped_at=%s WHERE name=%s;
 '''
 
 # TODO: understanding di scheduler works not only once
@@ -30,21 +33,17 @@ class DetikcomSpider(scrapy.Spider):
         'http://m.detik.com/news/indeksfokus/67/jakarta-memilih/1',
     )
 
+    # Initialize database connection then retrieve media ID and
+    # last_scraped_at information
     def __init__(self):
-        # Get media information from the database
         # Open database connection
         self.db = mysql.connect(host=ROJAK_DB_HOST, port=ROJAK_DB_PORT,
             user=ROJAK_DB_USER, passwd=ROJAK_DB_PASS, db=ROJAK_DB_NAME)
         self.cursor = self.db.cursor()
 
-        # Using UTF-8 Encoding
-        self.db.set_character_set('utf8')
-        self.cursor.execute('SET NAMES utf8;')
-        self.cursor.execute('SET CHARACTER SET utf8;')
-        self.cursor.execute('SET character_set_connection=utf8;')
-
         self.media = {}
         try:
+            # Get media information from the database
             self.logger.info('Fetching media information')
             self.cursor.execute(sql_get_media, [self.name])
             row = self.cursor.fetchone()
@@ -52,7 +51,56 @@ class DetikcomSpider(scrapy.Spider):
             self.media['last_scraped_at'] = row[1]
         except mysql.Error as err:
             self.logger.error('Unable to fetch media data: %s', err)
-            raise scrapy.exceptions.NotConfigured('Unable to fetch media data')
+            raise NotConfigured('Unable to fetch media data: %s' % err)
+
+        if ROJAK_SLACK_TOKEN != '':
+            self.slack = Slacker(ROJAK_SLACK_TOKEN)
+        else:
+            raise NotConfigured('ROJAK_SLACK_TOKEN is not set')
+
+    # Capture the signal spider_opened and spider_closed
+    # https://doc.scrapy.org/en/latest/topics/signals.html
+    @classmethod
+    def from_crawler(cls, crawler, *args, **kwargs):
+        spider = super(DetikcomSpider, cls).from_crawler(crawler,
+                *args, **kwargs)
+        crawler.signals.connect(spider.spider_opened,
+                signal=signals.spider_opened)
+        crawler.signals.connect(spider.spider_closed,
+                signal=signals.spider_closed)
+        return spider
+
+    def spider_opened(self, spider):
+        # Using UTF-8 Encoding
+        self.db.set_character_set('utf8')
+        self.cursor.execute('SET NAMES utf8;')
+        self.cursor.execute('SET CHARACTER SET utf8;')
+        self.cursor.execute('SET character_set_connection=utf8;')
+
+    def spider_closed(self, spider, reason):
+        spider.logger.info('Spider closed: %s %s', spider.name, reason)
+        # if spider finished without error update last_scraped_at
+        if reason == 'finished':
+            try:
+                self.logger.info('Updating media last_scraped_at information')
+                self.cursor.execute(sql_update_media, [datetime.now(),
+                    self.name])
+                self.db.commit()
+                self.db.close()
+            except mysql.Error as err:
+                self.logger.error('Unable to update last_scraped_at: %s', err)
+                self.db.rollback()
+                self.db.close()
+                error_msg = '{}: Unable to update last_scraped_at: {}'.format(
+                        spider.name, err)
+                self.slack.chat.post_message('#rojak-pantau-errors', error_msg,
+                        as_user=True)
+        else:
+            # Send error to slack
+            error_msg = '{}: Spider fail because: {}'.format(
+                    self.name, reason)
+            self.slack.chat.post_message('#rojak-pantau-errors', error_msg,
+                        as_user=True)
 
     def parse(self, response):
         self.logger.info('parse: %s' % response)
@@ -74,15 +122,16 @@ class DetikcomSpider(scrapy.Spider):
                 published_at = datetime.strptime(info_time,
                     '%d %b %Y, %H:%M')
             except Exception as e:
-                raise CloseSpider('parse: Cannot parse date: %s' % e)
+                raise CloseSpider('cannot_parse_date: %s' % e)
 
-            if media['last_scraped_at'] >= published_at:
+            if self.media['last_scraped_at'] >= published_at:
                 is_scraped = True
                 break
             # For each url we create new scrapy request
             yield scrapy.Request(url, callback=self.parse_news)
 
         if is_scraped:
+            self.logger.info('Media have no update')
             return
 
         if response.css('a.btn_more'):
@@ -94,16 +143,21 @@ class DetikcomSpider(scrapy.Spider):
             next_page_url = response.urljoin(next_page)
             yield scrapy.Request(next_page_url, callback=self.parse)
 
-    # Callback for parsing a news
+    # Collect news item
     def parse_news(self, response):
         self.logger.info('parse_news: %s' % response)
 
+        # Initialize item loader
         # extract news title, published_at, author, content, url
-        url = response.url
+        loader = ItemLoader(item=News(), response=response)
+        loader.add_value('url', response.url)
         title = response.css('div.detail_area > h1.jdl::text').extract()[0]
+        loader.add_value('title', title)
         author_name = response.css('div.author > strong::text').extract()[0]
+        loader.add_value('author_name', author_name)
         raw_content = response.css('article > div.text_detail::text').extract()
         raw_content = ' '.join(raw_content)
+        loader.add_value('raw_content', raw_content)
 
         # Parse date information
         try:
@@ -111,20 +165,13 @@ class DetikcomSpider(scrapy.Spider):
             date_str = response.css('div.detail_area > div.date::text').extract()[0]
             # Example: '15 Sep 2016, 18:33'
             date_str = ' '.join(date_str.split(' ')[1:5])
-            self.logger.info('parse_news: date_str: %s', date_str)
+            self.logger.info('parse_date: parse_news: date_str: %s', date_str)
             published_at = datetime.strptime(date_str,
                 '%d %b %Y, %H:%M')
+            loader.add_value('published_at', published_at)
         except Exception as e:
-            raise CloseSpider('parse_news: Cannot parse date: %s' % e)
+            raise CloseSpider('cannot_parse_date: %s' % e)
 
-        # Insert to the database
-        try:
-            self.cursor.execute(sql_insert_news, [self.media['id'], title,
-                raw_content, url, author_name, published_at])
-            self.db.commit()
-        except mysql.Error as err:
-            self.db.rollback()
-            raise CloseSpider('parse_news: Cannot save news: %s' % err)
-
-
+        # Move scraped news to pipeline
+        return loader.load_item()
 

--- a/rojak-pantau/rojak_pantau/spiders/detikcom.py
+++ b/rojak-pantau/rojak_pantau/spiders/detikcom.py
@@ -1,14 +1,130 @@
 # -*- coding: utf-8 -*-
 import scrapy
+import MySQLdb as mysql
+import os
+from datetime import datetime
+from scrapy.exceptions import CloseSpider
 
+ROJAK_DB_HOST = os.getenv('ROJAK_DB_HOST', 'localhost')
+ROJAK_DB_PORT = int(os.getenv('ROJAK_DB_PORT', 3306))
+ROJAK_DB_USER = os.getenv('ROJAK_DB_USER', 'root')
+ROJAK_DB_PASS = os.getenv('ROJAK_DB_PASS', 'rojak')
+ROJAK_DB_NAME = os.getenv('ROJAK_DB_NAME', 'rojak_database')
 
+sql_get_media = '''
+SELECT id,last_scraped_at FROM media WHERE name=%s;
+'''
+
+sql_insert_news = '''
+INSERT INTO `news`(`media_id`, `title`, `raw_content`,
+    `url`, `author_name`, `published_at`)
+VALUES (%s, %s, %s, %s, %s, %s);
+'''
+
+# TODO: understanding di scheduler works not only once
+# TODO: save state last_scraped_at
 class DetikcomSpider(scrapy.Spider):
     name = "detikcom"
     allowed_domains = ["detik.com"]
     start_urls = (
-        'http://m.detik.com/news/indeksfokus/67/jakarta-memilih',
+        'http://m.detik.com/news/indeksfokus/67/jakarta-memilih/1',
     )
 
+    def __init__(self):
+        # Get media information from the database
+        # Open database connection
+        self.db = mysql.connect(host=ROJAK_DB_HOST, port=ROJAK_DB_PORT,
+            user=ROJAK_DB_USER, passwd=ROJAK_DB_PASS, db=ROJAK_DB_NAME)
+        self.cursor = self.db.cursor()
+
+        # Using UTF-8 Encoding
+        self.db.set_character_set('utf8')
+        self.cursor.execute('SET NAMES utf8;')
+        self.cursor.execute('SET CHARACTER SET utf8;')
+        self.cursor.execute('SET character_set_connection=utf8;')
+
+        self.media = {}
+        try:
+            self.logger.info('Fetching media information')
+            self.cursor.execute(sql_get_media, [self.name])
+            row = self.cursor.fetchone()
+            self.media['id'] = row[0]
+            self.media['last_scraped_at'] = row[1]
+        except mysql.Error as err:
+            self.logger.error('Unable to fetch media data: %s', err)
+            raise scrapy.exceptions.NotConfigured('Unable to fetch media data')
+
     def parse(self, response):
-        print '== DEBUG:', response
-        pass
+        self.logger.info('parse: %s' % response)
+        is_scraped = False
+
+        # Get list of news from the current page
+        for article in response.css('article'):
+            url = article.css('a::attr(href)').extract()[0]
+            # Example 'detikNews | Sabtu 08 Oct 2016, 14:54 WIB'
+            info = article.css('a > .text > span.info::text').extract()[0]
+
+            # Parse date information
+            try:
+                # Example 'Sabtu 08 Oct 2016, 14:54 WIB'
+                info_time = info.split('|')[1].strip()
+                # Example '08 Oct 2016, 14:54'
+                info_time = ' '.join(info_time.split(' ')[1:5])
+                self.logger.info('info_time: %s', info_time)
+                published_at = datetime.strptime(info_time,
+                    '%d %b %Y, %H:%M')
+            except Exception as e:
+                raise CloseSpider('parse: Cannot parse date: %s' % e)
+
+            if media['last_scraped_at'] >= published_at:
+                is_scraped = True
+                break
+            # For each url we create new scrapy request
+            yield scrapy.Request(url, callback=self.parse_news)
+
+        if is_scraped:
+            return
+
+        if response.css('a.btn_more'):
+            next_page = response.css('a.btn_more::attr(href)')[0].extract()
+            next_page_url = response.urljoin(next_page)
+            yield scrapy.Request(next_page_url, callback=self.parse)
+        elif response.css('div.pag-nextprev > a'):
+            next_page = response.css('div.pag-nextprev > a::attr(href)')[1].extract()
+            next_page_url = response.urljoin(next_page)
+            yield scrapy.Request(next_page_url, callback=self.parse)
+
+    # Callback for parsing a news
+    def parse_news(self, response):
+        self.logger.info('parse_news: %s' % response)
+
+        # extract news title, published_at, author, content, url
+        url = response.url
+        title = response.css('div.detail_area > h1.jdl::text').extract()[0]
+        author_name = response.css('div.author > strong::text').extract()[0]
+        raw_content = response.css('article > div.text_detail::text').extract()
+        raw_content = ' '.join(raw_content)
+
+        # Parse date information
+        try:
+            # Example: Kamis 15 Sep 2016, 18:33 WIB
+            date_str = response.css('div.detail_area > div.date::text').extract()[0]
+            # Example: '15 Sep 2016, 18:33'
+            date_str = ' '.join(date_str.split(' ')[1:5])
+            self.logger.info('parse_news: date_str: %s', date_str)
+            published_at = datetime.strptime(date_str,
+                '%d %b %Y, %H:%M')
+        except Exception as e:
+            raise CloseSpider('parse_news: Cannot parse date: %s' % e)
+
+        # Insert to the database
+        try:
+            self.cursor.execute(sql_insert_news, [self.media['id'], title,
+                raw_content, url, author_name, published_at])
+            self.db.commit()
+        except mysql.Error as err:
+            self.db.rollback()
+            raise CloseSpider('parse_news: Cannot save news: %s' % err)
+
+
+


### PR DESCRIPTION
Inialisasi `rojak-pantau` untuk memantau detik.com

Sudah bisa men-scrap semua artikel tentang Pilkada Jakarta.

Beberapa tantangan yang belum di selesaikan:
1. Deploy `rojak-pantau-detik`
2. Menyimpan state `rojak-pantau-detik` di table `media` => `last_scraped_at`

Solusi dari masalah di atas, kita focus one machine dlu nanti baru scale up kalau resourcenya di kira kurang dan kita sudah berhasil membuat statenya. Untuk state kita hanya menscrape news baru saja dari `last_scraped_at` terakhir.
