### PR TITLE
[rojak-pantau] Fix timezone issue

### DIFF
--- a/rojak-pantau/rojak_pantau/spiders/detikcom.py
+++ b/rojak-pantau/rojak_pantau/spiders/detikcom.py
@@ -3,11 +3,14 @@ import scrapy
 import MySQLdb as mysql
 import os
 from datetime import datetime
+from slacker import Slacker
+
 from scrapy.exceptions import CloseSpider, NotConfigured
 from scrapy import signals
-from rojak_pantau.items import News
 from scrapy.loader import ItemLoader
-from slacker import Slacker
+
+from rojak_pantau.items import News
+from rojak_pantau.util.wib_to_utc import wib_to_utc
 
 ROJAK_DB_HOST = os.getenv('ROJAK_DB_HOST', 'localhost')
 ROJAK_DB_PORT = int(os.getenv('ROJAK_DB_PORT', 3306))
@@ -21,7 +24,7 @@ SELECT id,last_scraped_at FROM media WHERE name=%s;
 '''
 
 sql_update_media = '''
-UPDATE `media` SET last_scraped_at=%s WHERE name=%s;
+UPDATE `media` SET last_scraped_at=UTC_TIMESTAMP() WHERE name=%s;
 '''
 
 class DetikcomSpider(scrapy.Spider):
@@ -83,8 +86,7 @@ class DetikcomSpider(scrapy.Spider):
         if reason == 'finished':
             try:
                 self.logger.info('Updating media last_scraped_at information')
-                self.cursor.execute(sql_update_media, [datetime.now(),
-                    self.name])
+                self.cursor.execute(sql_update_media, [self.name])
                 self.db.commit()
                 self.db.close()
             except mysql.Error as err:
@@ -121,8 +123,9 @@ class DetikcomSpider(scrapy.Spider):
                 # Example '08 Oct 2016, 14:54'
                 info_time = ' '.join(info_time.split(' ')[1:5])
                 self.logger.info('info_time: %s', info_time)
-                published_at = datetime.strptime(info_time,
+                published_at_wib = datetime.strptime(info_time,
                     '%d %b %Y, %H:%M')
+                published_at = wib_to_utc(published_at_wib)
             except Exception as e:
                 raise CloseSpider('cannot_parse_date: %s' % e)
 
@@ -158,7 +161,6 @@ class DetikcomSpider(scrapy.Spider):
         author_name = response.css('div.author > strong::text').extract()[0]
         loader.add_value('author_name', author_name)
         raw_content = response.css('article > div.text_detail').extract()[0]
-        raw_content = ' '.join(raw_content)
         loader.add_value('raw_content', raw_content)
 
         # Parse date information

--- a/rojak-pantau/rojak_pantau/spiders/metrotvnews.py
+++ b/rojak-pantau/rojak_pantau/spiders/metrotvnews.py
@@ -23,7 +23,7 @@ SELECT id,last_scraped_at FROM media WHERE name=%s;
 '''
 
 sql_update_media = '''
-UPDATE `media` SET last_scraped_at=%s WHERE name=%s;
+UPDATE `media` SET last_scraped_at=UTC_TIMESTAMP() WHERE name=%s;
 '''
 
 
@@ -87,8 +87,7 @@ class MetrotvnewsSpider(Spider):
         if reason == 'finished':
             try:
                 self.logger.info('Updating media last_scraped_at information')
-                self.cursor.execute(sql_update_media, [datetime.utcnow(),
-                    self.name])
+                self.cursor.execute(sql_update_media, [self.name])
                 self.db.commit()
                 self.db.close()
             except mysql.Error as err:


### PR DESCRIPTION
Fix timezone issue di spider `detikcom` dan error di `raw_content`. 

Ada perubahan sql untuk update data media, sebelumnya:

``` sql
UPDATE `media` SET last_scraped_at=%s WHERE name=%s;
```

jadi:

``` sql
UPDATE `media` SET last_scraped_at=UTC_TIMESTAMP() WHERE name=%s;
```

Jadi kita gak perlu call `datetime.utcnow()`.

cc: @girikuncoro @imrenagi 
