### PR TITLE
[rojak-database] fix invalid default value for last_scraped_at

### DIFF
--- a/rojak-database/rojak_schema_latest.sql
+++ b/rojak-database/rojak_schema_latest.sql
@@ -53,7 +53,7 @@ CREATE TABLE `media` (
     `fbpage_username` varchar(255) collate utf8_unicode_ci UNIQUE,
     `twitter_username` varchar(255) collate utf8_unicode_ci UNIQUE,
     `instagram_username` varchar(255) collate utf8_unicode_ci UNIQUE,
-    `last_scraped_at` timestamp NOT NULL DEFAULT '1970-01-01 00:00:01',
+    `last_scraped_at` timestamp NOT NULL DEFAULT '1970-01-02 00:00:01',
     `inserted_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
         ON UPDATE CURRENT_TIMESTAMP,


### PR DESCRIPTION
```
mysql> CREATE TABLE `media` (
    ->     `id` int(10) unsigned NOT NULL UNIQUE auto_increment,
    ->     `name` varchar(255) collate utf8_unicode_ci NOT NULL UNIQUE,
    ->     `website_url` varchar(255) collate utf8_unicode_ci NOT NULL UNIQUE,
    ->     `logo_url` varchar(255) collate utf8_unicode_ci UNIQUE,
    ->     `fbpage_username` varchar(255) collate utf8_unicode_ci UNIQUE,
    ->     `twitter_username` varchar(255) collate utf8_unicode_ci UNIQUE,
    ->     `instagram_username` varchar(255) collate utf8_unicode_ci UNIQUE,
    ->     `last_scraped_at` timestamp NOT NULL DEFAULT '1970-01-01 00:00:01',
    ->     `inserted_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
    ->     `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
    ->         ON UPDATE CURRENT_TIMESTAMP,
    ->     PRIMARY KEY (`id`)
    -> ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
ERROR 1067 (42000): Invalid default value for 'last_scraped_at'
```
