### PR TITLE
[rojak-pantau] OkeZone: tambah descendant-or-self::img untuk remove <img> tag

### DIFF
--- a/rojak-pantau/rojak_pantau/spiders/okezone.py
+++ b/rojak-pantau/rojak_pantau/spiders/okezone.py
@@ -116,6 +116,7 @@ class OkezoneSpider(BaseSpider):
                     descendant-or-self::div|
                     descendant-or-self::span|
                     descendant-or-self::image|
+                    descendant-or-self::img|
                     descendant-or-self::iframe
                 )]
         '''


### PR DESCRIPTION
Ternyata di #119 belum re-remove `img` tagnya. Patch ini untuk remove tag tersebut 
