### PR TITLE
[rojak-api] Implementation of API spec v0.2 (tanpa sentiment)

### DIFF
--- a/rojak-api/mix.exs
+++ b/rojak-api/mix.exs
@@ -19,7 +19,7 @@ defmodule RojakAPI.Mixfile do
   def application do
     [mod: {RojakAPI, []},
      applications: [:phoenix, :phoenix_pubsub, :cowboy, :logger, :gettext,
-                    :phoenix_ecto, :mariaex]]
+                    :phoenix_ecto, :mariaex, :params]]
   end
 
   # Specifies which paths to compile per environment.
@@ -36,6 +36,7 @@ defmodule RojakAPI.Mixfile do
      {:mariaex, ">= 0.0.0"},
      {:gettext, "~> 0.11"},
      {:cowboy, "~> 1.0"},
+     {:params, "~> 2.0.1"},
      {:distillery, "~> 0.9.0"}]
   end
 

--- a/rojak-api/mix.lock
+++ b/rojak-api/mix.lock
@@ -8,6 +8,7 @@
   "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
   "mariaex": {:hex, :mariaex, "0.7.8", "77bcc9e898a7f2231022ac0112f2832158d289fa3ef1e0020ceb61d00403134c", [:mix], [{:db_connection, "~> 1.0.0-rc", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
+  "params": {:hex, :params, "2.0.1", "10cbc61dcdeb0fdc7d8f28788867da83038f8b6f494094547e581f637126e06b", [:mix], [{:ecto, "~> 2.0.1", [hex: :ecto, optional: false]}]},
   "phoenix": {:hex, :phoenix, "1.2.1", "6dc592249ab73c67575769765b66ad164ad25d83defa3492dc6ae269bd2a68ab", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
   "phoenix_ecto": {:hex, :phoenix_ecto, "3.0.1", "42eb486ef732cf209d0a353e791806721f33ff40beab0a86f02070a5649ed00a", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: false]}, {:phoenix_html, "~> 2.6", [hex: :phoenix_html, optional: true]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.1", "c10ddf6237007c804bf2b8f3c4d5b99009b42eca3a0dfac04ea2d8001186056a", [:mix], []},

--- a/rojak-api/test/v1/candidate/candidate_controller_test.exs
+++ b/rojak-api/test/v1/candidate/candidate_controller_test.exs
@@ -1,0 +1,47 @@
+defmodule RojakAPI.CandidateControllerTest do
+  use RojakAPI.ConnCase
+
+  @candidate_properties [
+    "id",
+    "full_name",
+    "alias_name",
+    "place_of_birth",
+    "date_of_birth",
+    "religion",
+    "website_url",
+    "photo_url",
+    "fbpage_username",
+    "twitter_username",
+    "instagram_username",
+  ]
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  test "lists all entries on index", %{conn: conn} do
+    conn = get conn, v1_candidate_path(conn, :index)
+    candidate_list = json_response(conn, 200)
+    assert Enum.count(candidate_list) >= 0
+
+    candidate_item = List.first(candidate_list)
+    assert item_has_valid_properties?(candidate_item), "Item is missing valid properties."
+  end
+
+  test "shows chosen resource", %{conn: conn} do
+    conn = get conn, v1_candidate_path(conn, :show, 1)
+    candidate_item = json_response(conn, 200)
+    assert item_has_valid_properties?(candidate_item), "Item is missing valid properties."
+  end
+
+  test "renders page not found when id is nonexistent", %{conn: conn} do
+    assert_error_sent 404, fn ->
+      get conn, v1_candidate_path(conn, :show, -1)
+    end
+  end
+
+  defp item_has_valid_properties?(item) do
+    Enum.all?(@candidate_properties, &(Map.has_key?(item, &1)))
+  end
+
+end

--- a/rojak-api/test/v1/candidate/candidate_controller_test.exs
+++ b/rojak-api/test/v1/candidate/candidate_controller_test.exs
@@ -13,6 +13,8 @@ defmodule RojakAPI.CandidateControllerTest do
     "fbpage_username",
     "twitter_username",
     "instagram_username",
+    "inserted_at",
+    "updated_at",
   ]
 
   setup %{conn: conn} do

--- a/rojak-api/test/v1/candidate/candidate_controller_test.exs
+++ b/rojak-api/test/v1/candidate/candidate_controller_test.exs
@@ -30,10 +30,42 @@ defmodule RojakAPI.CandidateControllerTest do
     assert item_has_valid_properties?(candidate_item), "Item is missing valid properties."
   end
 
+  test "allows embedding sentiments on index", %{conn: conn} do
+    conn = get conn, v1_candidate_path(conn, :index), %{embed: ["sentiments"]}
+    candidate_list = json_response(conn, 200)
+    assert Enum.count(candidate_list) >= 0
+
+    candidate_item = List.first(candidate_list)
+    assert item_has_valid_properties?(candidate_item), "Item is missing valid properties."
+
+    # TODO: check if sentiments are embedded
+  end
+
+  test "renders invalid parameters when trying to embed invalid field on index", %{conn: conn} do
+    assert_error_sent 422, fn ->
+      get conn, v1_candidate_path(conn, :index), %{embed: ["foo"]}
+    end
+  end
+
   test "shows chosen resource", %{conn: conn} do
     conn = get conn, v1_candidate_path(conn, :show, 1)
     candidate_item = json_response(conn, 200)
     assert item_has_valid_properties?(candidate_item), "Item is missing valid properties."
+  end
+
+  test "allows embedding sentiments and pairing on show", %{conn: conn} do
+    conn = get conn, v1_candidate_path(conn, :show, 1), %{embed: ["sentiments", "pairing"]}
+    candidate_item = json_response(conn, 200)
+    assert item_has_valid_properties?(candidate_item), "Item is missing valid properties."
+
+    # TODO: check if sentiments are embedded
+    assert Map.has_key?(candidate_item, "pairing")
+  end
+
+  test "renders invalid parameters when trying to embed invalid field on show", %{conn: conn} do
+    assert_error_sent 422, fn ->
+      get conn, v1_candidate_path(conn, :show, 1), %{embed: ["foo"]}
+    end
   end
 
   test "renders page not found when id is nonexistent", %{conn: conn} do

--- a/rojak-api/test/v1/candidate/candidate_controller_test.exs
+++ b/rojak-api/test/v1/candidate/candidate_controller_test.exs
@@ -1,21 +1,21 @@
 defmodule RojakAPI.CandidateControllerTest do
   use RojakAPI.ConnCase
 
-  @candidate_properties [
-    "id",
-    "full_name",
-    "alias_name",
-    "place_of_birth",
-    "date_of_birth",
-    "religion",
-    "website_url",
-    "photo_url",
-    "fbpage_username",
-    "twitter_username",
-    "instagram_username",
-    "inserted_at",
-    "updated_at",
-  ]
+  @candidate_properties ~w(
+    id
+    full_name
+    alias_name
+    place_of_birth
+    date_of_birth
+    religion
+    website_url
+    photo_url
+    fbpage_username
+    twitter_username
+    instagram_username
+    inserted_at
+    updated_at
+  )
 
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}

--- a/rojak-api/test/v1/media/media_controller_test.exs
+++ b/rojak-api/test/v1/media/media_controller_test.exs
@@ -9,6 +9,8 @@ defmodule RojakAPI.MediaControllerTest do
     "fbpage_username",
     "twitter_username",
     "instagram_username",
+    "inserted_at",
+    "updated_at",
   ]
 
   setup %{conn: conn} do

--- a/rojak-api/test/v1/media/media_controller_test.exs
+++ b/rojak-api/test/v1/media/media_controller_test.exs
@@ -1,17 +1,17 @@
 defmodule RojakAPI.MediaControllerTest do
   use RojakAPI.ConnCase
 
-  @media_properties [
-    "id",
-    "name",
-    "website_url",
-    "logo_url",
-    "fbpage_username",
-    "twitter_username",
-    "instagram_username",
-    "inserted_at",
-    "updated_at",
-  ]
+  @media_properties ~w(
+    id
+    name
+    website_url
+    logo_url
+    fbpage_username
+    twitter_username
+    instagram_username
+    inserted_at
+    updated_at
+  )
 
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}

--- a/rojak-api/test/v1/media/media_controller_test.exs
+++ b/rojak-api/test/v1/media/media_controller_test.exs
@@ -26,6 +26,40 @@ defmodule RojakAPI.MediaControllerTest do
     assert item_has_valid_properties?(media_item), "Item is missing valid properties."
   end
 
+  test "allows limit on index", %{conn: conn} do
+    conn = get conn, v1_media_path(conn, :index), %{limit: 1}
+    media_list = json_response(conn, 200)
+    assert Enum.count(media_list) == 1
+  end
+
+  test "limit defaults to 10", %{conn: conn} do
+    conn = get conn, v1_media_path(conn, :index)
+    media_list = json_response(conn, 200)
+    assert Enum.count(media_list) == 10
+  end
+
+  test "renders invalid parameters when limit is not an integer", %{conn: conn} do
+    assert_error_sent 422, fn ->
+      get conn, v1_media_path(conn, :index), %{limit: "foo"}
+    end
+  end
+
+  test "allows offset on index", %{conn: conn} do
+    conn = get conn, v1_media_path(conn, :index), %{offset: 0}
+    media_list = json_response(conn, 200)
+
+    conn = get conn, v1_media_path(conn, :index), %{offset: 1}
+    media_list_offset = json_response(conn, 200)
+
+    assert Enum.at(media_list, 1) == Enum.at(media_list_offset, 0)
+  end
+
+  test "renders invalid parameters when offset is not an integer", %{conn: conn} do
+    assert_error_sent 422, fn ->
+      get conn, v1_media_path(conn, :index), %{offset: "foo"}
+    end
+  end
+
   test "shows chosen resource", %{conn: conn} do
     conn = get conn, v1_media_path(conn, :show, 1)
     media_item = json_response(conn, 200)

--- a/rojak-api/test/v1/news/news_controller_test.exs
+++ b/rojak-api/test/v1/news/news_controller_test.exs
@@ -1,15 +1,15 @@
 defmodule RojakAPI.NewsControllerTest do
   use RojakAPI.ConnCase
 
-  @news_properties [
-    "id",
-    "media_id",
-    "title",
-    "url",
-    "author_name",
-    "inserted_at",
-    "updated_at",
-  ]
+  @news_properties ~w(
+    id
+    media_id
+    title
+    url
+    author_name
+    inserted_at
+    updated_at
+  )
 
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}

--- a/rojak-api/test/v1/news/news_controller_test.exs
+++ b/rojak-api/test/v1/news/news_controller_test.exs
@@ -1,0 +1,41 @@
+defmodule RojakAPI.NewsControllerTest do
+  use RojakAPI.ConnCase
+
+  @news_properties [
+    "id",
+    "media_id",
+    "title",
+    "url",
+    "author_name",
+  ]
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  test "lists all entries on index", %{conn: conn} do
+    conn = get conn, v1_news_path(conn, :index)
+    news_list = json_response(conn, 200)
+    assert Enum.count(news_list) >= 0
+
+    news_item = List.first(news_list)
+    assert item_has_valid_properties?(news_item), "Item is missing valid properties."
+  end
+
+  test "shows chosen resource", %{conn: conn} do
+    conn = get conn, v1_news_path(conn, :show, 1)
+    news_item = json_response(conn, 200)
+    assert item_has_valid_properties?(news_item), "Item is missing valid properties."
+  end
+
+  test "renders page not found when id is nonexistent", %{conn: conn} do
+    assert_error_sent 404, fn ->
+      get conn, v1_news_path(conn, :show, -1)
+    end
+  end
+
+  defp item_has_valid_properties?(item) do
+    Enum.all?(@news_properties, &(Map.has_key?(item, &1)))
+  end
+
+end

--- a/rojak-api/test/v1/news/news_controller_test.exs
+++ b/rojak-api/test/v1/news/news_controller_test.exs
@@ -24,10 +24,99 @@ defmodule RojakAPI.NewsControllerTest do
     assert item_has_valid_properties?(news_item), "Item is missing valid properties."
   end
 
+  test "allows limit on index", %{conn: conn} do
+    conn = get conn, v1_news_path(conn, :index), %{limit: 1}
+    news_list = json_response(conn, 200)
+    assert Enum.count(news_list) == 1
+  end
+
+  test "limit defaults to 10", %{conn: conn} do
+    conn = get conn, v1_news_path(conn, :index)
+    news_list = json_response(conn, 200)
+    assert Enum.count(news_list) == 10
+  end
+
+  test "renders invalid parameters when limit is not an integer", %{conn: conn} do
+    assert_error_sent 422, fn ->
+      get conn, v1_news_path(conn, :index), %{limit: "foo"}
+    end
+  end
+
+  test "allows offset on index", %{conn: conn} do
+    conn = get conn, v1_news_path(conn, :index), %{offset: 0}
+    news_list = json_response(conn, 200)
+
+    conn = get conn, v1_news_path(conn, :index), %{offset: 1}
+    news_list_offset = json_response(conn, 200)
+
+    assert Enum.at(news_list, 1) == Enum.at(news_list_offset, 0)
+  end
+
+  test "renders invalid parameters when offset is not an integer", %{conn: conn} do
+    assert_error_sent 422, fn ->
+      get conn, v1_news_path(conn, :index), %{offset: "foo"}
+    end
+  end
+
+  test "allows embedding mentions on index", %{conn: conn} do
+    conn = get conn, v1_news_path(conn, :index), %{embed: ["mentions"]}
+    news_list = json_response(conn, 200)
+    assert Enum.count(news_list) >= 0
+
+    news_item = List.first(news_list)
+    assert Map.has_key?(news_item, "mentions")
+  end
+
+  test "allows filtering by media id", %{conn: conn} do
+    conn = get conn, v1_news_path(conn, :index), %{media_id: ["1"]}
+    news_list = json_response(conn, 200)
+    assert Enum.all? news_list, fn news_item ->
+      Map.get(news_item, "media_id") == 1
+    end
+  end
+
+  test "renders invalid parameters when media_id is not an array of integers", %{conn: conn} do
+    assert_error_sent 422, fn ->
+      get conn, v1_news_path(conn, :index), %{media_id: "1"}
+    end
+
+    assert_error_sent 422, fn ->
+      get conn, v1_news_path(conn, :index), %{media_id: ["foo"]}
+    end
+  end
+
+  test "allows filtering by mentioned candidate id", %{conn: conn} do
+    conn = get conn, v1_news_path(conn, :index), %{candidate_id: ["1"], embed: ["mentions"]}
+    news_list = json_response(conn, 200)
+    assert Enum.all? news_list, fn news_item ->
+      mentions = Map.get(news_item, "mentions")
+      Enum.any? mentions, fn mentioned_candidate ->
+        Map.get(mentioned_candidate, "id") == 1
+      end
+    end
+  end
+
+  test "renders invalid parameters when candidate_id is not an array of integers", %{conn: conn} do
+    assert_error_sent 422, fn ->
+      get conn, v1_news_path(conn, :index), %{candidate_id: "1"}
+    end
+
+    assert_error_sent 422, fn ->
+      get conn, v1_news_path(conn, :index), %{candidate_id: ["foo"]}
+    end
+  end
+
   test "shows chosen resource", %{conn: conn} do
     conn = get conn, v1_news_path(conn, :show, 1)
     news_item = json_response(conn, 200)
     assert item_has_valid_properties?(news_item), "Item is missing valid properties."
+  end
+
+  test "allows embedding mentions on show", %{conn: conn} do
+    conn = get conn, v1_news_path(conn, :show, 1), %{embed: ["mentions"]}
+    news_item = json_response(conn, 200)
+
+    assert Map.has_key?(news_item, "mentions")
   end
 
   test "renders page not found when id is nonexistent", %{conn: conn} do

--- a/rojak-api/test/v1/news/news_controller_test.exs
+++ b/rojak-api/test/v1/news/news_controller_test.exs
@@ -7,6 +7,8 @@ defmodule RojakAPI.NewsControllerTest do
     "title",
     "url",
     "author_name",
+    "inserted_at",
+    "updated_at",
   ]
 
   setup %{conn: conn} do

--- a/rojak-api/test/v1/pairing/pairing_controller_test.exs
+++ b/rojak-api/test/v1/pairing/pairing_controller_test.exs
@@ -1,0 +1,46 @@
+defmodule RojakAPI.PairingControllerTest do
+  use RojakAPI.ConnCase
+
+  @pairing_properties [
+    "id",
+    "website_url",
+    "logo_url",
+    "fbpage_username",
+    "twitter_username",
+    "instagram_username",
+    "slogan",
+    "description",
+    "cagub_id",
+    "cawagub_id",
+  ]
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  test "lists all entries on index", %{conn: conn} do
+    conn = get conn, v1_pairing_path(conn, :index)
+    pairing_list = json_response(conn, 200)
+    assert Enum.count(pairing_list) >= 0
+
+    pairing_item = List.first(pairing_list)
+    assert item_has_valid_properties?(pairing_item), "Item is missing valid properties."
+  end
+
+  test "shows chosen resource", %{conn: conn} do
+    conn = get conn, v1_pairing_path(conn, :show, 1)
+    pairing_item = json_response(conn, 200)
+    assert item_has_valid_properties?(pairing_item), "Item is missing valid properties."
+  end
+
+  test "renders page not found when id is nonexistent", %{conn: conn} do
+    assert_error_sent 404, fn ->
+      get conn, v1_pairing_path(conn, :show, -1)
+    end
+  end
+
+  defp item_has_valid_properties?(item) do
+    Enum.all?(@pairing_properties, &(Map.has_key?(item, &1)))
+  end
+
+end

--- a/rojak-api/test/v1/pairing/pairing_controller_test.exs
+++ b/rojak-api/test/v1/pairing/pairing_controller_test.exs
@@ -3,6 +3,7 @@ defmodule RojakAPI.PairingControllerTest do
 
   @pairing_properties [
     "id",
+    "name",
     "website_url",
     "logo_url",
     "fbpage_username",
@@ -12,6 +13,8 @@ defmodule RojakAPI.PairingControllerTest do
     "description",
     "cagub_id",
     "cawagub_id",
+    "inserted_at",
+    "updated_at",
   ]
 
   setup %{conn: conn} do

--- a/rojak-api/test/v1/pairing/pairing_controller_test.exs
+++ b/rojak-api/test/v1/pairing/pairing_controller_test.exs
@@ -1,21 +1,21 @@
 defmodule RojakAPI.PairingControllerTest do
   use RojakAPI.ConnCase
 
-  @pairing_properties [
-    "id",
-    "name",
-    "website_url",
-    "logo_url",
-    "fbpage_username",
-    "twitter_username",
-    "instagram_username",
-    "slogan",
-    "description",
-    "cagub_id",
-    "cawagub_id",
-    "inserted_at",
-    "updated_at",
-  ]
+  @pairing_properties ~w(
+    id
+    name
+    website_url
+    logo_url
+    fbpage_username
+    twitter_username
+    instagram_username
+    slogan
+    description
+    cagub_id
+    cawagub_id
+    inserted_at
+    updated_at
+  )
 
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}

--- a/rojak-api/test/v1/pairing/pairing_controller_test.exs
+++ b/rojak-api/test/v1/pairing/pairing_controller_test.exs
@@ -30,10 +30,42 @@ defmodule RojakAPI.PairingControllerTest do
     assert item_has_valid_properties?(pairing_item), "Item is missing valid properties."
   end
 
+  test "allows embedding sentiments on index", %{conn: conn} do
+    conn = get conn, v1_pairing_path(conn, :index), %{embed: ["sentiments"]}
+    pairing_list = json_response(conn, 200)
+    assert Enum.count(pairing_list) >= 0
+
+    pairing_item = List.first(pairing_list)
+    assert item_has_valid_properties?(pairing_item), "Item is missing valid properties."
+
+    # TODO: check if sentiments are embedded
+  end
+
+  test "renders invalid parameters when trying to embed invalid field on index", %{conn: conn} do
+    assert_error_sent 422, fn ->
+      get conn, v1_pairing_path(conn, :index), %{embed: ["foo"]}
+    end
+  end
+
   test "shows chosen resource", %{conn: conn} do
     conn = get conn, v1_pairing_path(conn, :show, 1)
     pairing_item = json_response(conn, 200)
     assert item_has_valid_properties?(pairing_item), "Item is missing valid properties."
+  end
+
+  test "allows embedding sentiments and candidates on show", %{conn: conn} do
+    conn = get conn, v1_pairing_path(conn, :show, 1), %{embed: ["sentiments", "candidates"]}
+    pairing_item = json_response(conn, 200)
+    assert item_has_valid_properties?(pairing_item), "Item is missing valid properties."
+
+    # TODO: check if sentiments are embedded
+    assert Map.has_key?(pairing_item, "candidates")
+  end
+
+  test "renders invalid parameters when trying to embed invalid field on show", %{conn: conn} do
+    assert_error_sent 422, fn ->
+      get conn, v1_pairing_path(conn, :show, 1), %{embed: ["foo"]}
+    end
   end
 
   test "renders page not found when id is nonexistent", %{conn: conn} do

--- a/rojak-api/test/views/error_view_test.exs
+++ b/rojak-api/test/views/error_view_test.exs
@@ -6,16 +6,22 @@ defmodule RojakAPI.ErrorViewTest do
 
   test "renders 404.json" do
     assert render(RojakAPI.ErrorView, "404.json", []) ==
-           %{errors: %{detail: "Page not found"}}
+           %{message: "item not found"}
+  end
+
+  test "renders 422.json" do
+    assert render(RojakAPI.ErrorView, "422.json", []) ==
+           %{message: "invalid parameters provided"}
   end
 
   test "render 500.json" do
     assert render(RojakAPI.ErrorView, "500.json", []) ==
-           %{errors: %{detail: "Internal server error"}}
+           %{message: "internal server error"}
   end
 
   test "render any other" do
     assert render(RojakAPI.ErrorView, "505.json", []) ==
-           %{errors: %{detail: "Internal server error"}}
+           %{message: "internal server error"}
   end
+
 end

--- a/rojak-api/web/common/errors/error_view.ex
+++ b/rojak-api/web/common/errors/error_view.ex
@@ -2,7 +2,7 @@ defmodule RojakAPI.ErrorView do
   use RojakAPI.Web, :view
 
   def render("404.json", _assigns) do
-    %{errors: %{detail: "Page not found"}}
+    %{message: "item not found"}
   end
 
   def render("422.json", _assigns) do
@@ -10,7 +10,7 @@ defmodule RojakAPI.ErrorView do
   end
 
   def render("500.json", _assigns) do
-    %{errors: %{detail: "Internal server error"}}
+    %{message: "internal server error"}
   end
 
   # In case no render clause matches or no

--- a/rojak-api/web/common/errors/error_view.ex
+++ b/rojak-api/web/common/errors/error_view.ex
@@ -5,6 +5,10 @@ defmodule RojakAPI.ErrorView do
     %{errors: %{detail: "Page not found"}}
   end
 
+  def render("422.json", _assigns) do
+    %{message: "invalid parameters provided"}
+  end
+
   def render("500.json", _assigns) do
     %{errors: %{detail: "Internal server error"}}
   end

--- a/rojak-api/web/models/candidate.ex
+++ b/rojak-api/web/models/candidate.ex
@@ -1,6 +1,9 @@
 defmodule RojakAPI.Candidate do
   use RojakAPI.Web, :model
 
+  # Self alias
+  alias RojakAPI.Candidate
+
   schema "candidate" do
     field :full_name, :string
     field :alias_name, :string
@@ -13,11 +16,39 @@ defmodule RojakAPI.Candidate do
     field :instagram_username, :string
     field :twitter_username, :string
 
+    # Virtual fields for embedding joins
+    field :pairing, :map, virtual: true
+
     # Relationship
     has_many :sentiments, RojakAPI.Sentiment
     many_to_many :mentioned_in, RojakAPI.News, join_through: "mention"
 
     timestamps()
+  end
+
+  def fetch(%{embed: embed}) do
+    Candidate
+    |> fetch_embed(embed)
+    |> Repo.all
+  end
+
+  def fetch_one(%{id: id, embed: embed}) do
+    Candidate
+    |> fetch_embed(embed)
+    |> Repo.get!(id)
+  end
+
+  defp fetch_embed(query, embed) when is_nil(embed), do: query
+  defp fetch_embed(query, embed) do
+    query
+    |> fetch_pairing(Enum.member?(embed, "pairing"))
+  end
+
+  defp fetch_pairing(query, embed?) when not embed?, do: query
+  defp fetch_pairing(query, _) do
+    from q in query,
+      join: p in RojakAPI.PairOfCandidates, on: q.id == p.cagub_id or q.id == p.cawagub_id,
+      select: %{q | pairing: p}
   end
 
 end

--- a/rojak-api/web/models/media.ex
+++ b/rojak-api/web/models/media.ex
@@ -1,6 +1,9 @@
 defmodule RojakAPI.Media do
   use RojakAPI.Web, :model
 
+  # Self-alias
+  alias RojakAPI.Media
+
   schema "media" do
     field :name, :string
     field :website_url, :string
@@ -13,6 +16,17 @@ defmodule RojakAPI.Media do
     has_many :news, RojakAPI.News
 
     timestamps()
+  end
+
+  def fetch(%{limit: limit, offset: offset}) do
+    query = from Media, limit: ^limit, offset: ^offset
+    query
+    |> Repo.all
+  end
+
+  def fetch_one(%{id: id}) do
+    Media
+    |> Repo.get!(id)
   end
 
 end

--- a/rojak-api/web/models/news.ex
+++ b/rojak-api/web/models/news.ex
@@ -3,8 +3,8 @@ defmodule RojakAPI.News do
 
   schema "news" do
     field :title, :string
-    field :content, :string
     field :url, :string
+    field :author_name, :string
 
     # Relationship
     belongs_to :media, RojakAPI.Media

--- a/rojak-api/web/models/news.ex
+++ b/rojak-api/web/models/news.ex
@@ -25,11 +25,13 @@ defmodule RojakAPI.News do
     query
     |> filter_by_media(media_id)
     |> filter_by_candidates(candidate_id)
+    |> fetch_embed(embed)
     |> Repo.all
   end
 
   def fetch_one(%{id: id, embed: embed}) do
     News
+    |> fetch_embed(embed)
     |> Repo.get!(id)
   end
 
@@ -44,6 +46,19 @@ defmodule RojakAPI.News do
     from q in query,
       join: c in assoc(q, :mentions),
       where: c.id in ^candidate_ids
+  end
+
+  defp fetch_embed(query, embed) when is_nil(embed), do: query
+  defp fetch_embed(query, embed) do
+    query
+    |> fetch_mentions(Enum.member?(embed, "mentions"))
+  end
+
+  defp fetch_mentions(query, embed?) when not embed?, do: query
+  defp fetch_mentions(query, _) do
+    from q in query,
+      join: m in assoc(q, :mentions),
+      preload: [mentions: m]
   end
 
 end

--- a/rojak-api/web/models/news.ex
+++ b/rojak-api/web/models/news.ex
@@ -24,6 +24,7 @@ defmodule RojakAPI.News do
       order_by: [desc: n.id]
     query
     |> filter_by_media(media_id)
+    |> filter_by_candidates(candidate_id)
     |> Repo.all
   end
 
@@ -36,6 +37,13 @@ defmodule RojakAPI.News do
   defp filter_by_media(query, media_ids) do
     from q in query,
       where: q.media_id in ^media_ids
+  end
+
+  defp filter_by_candidates(query, candidate_ids) when is_nil(candidate_ids), do: query
+  defp filter_by_candidates(query, candidate_ids) do
+    from q in query,
+      join: c in assoc(q, :mentions),
+      where: c.id in ^candidate_ids
   end
 
 end

--- a/rojak-api/web/models/news.ex
+++ b/rojak-api/web/models/news.ex
@@ -23,12 +23,19 @@ defmodule RojakAPI.News do
       offset: ^offset,
       order_by: [desc: n.id]
     query
+    |> filter_by_media(media_id)
     |> Repo.all
   end
 
   def fetch_one(%{id: id, embed: embed}) do
     News
     |> Repo.get!(id)
+  end
+
+  defp filter_by_media(query, media_ids) when is_nil(media_ids), do: query
+  defp filter_by_media(query, media_ids) do
+    from q in query,
+      where: q.media_id in ^media_ids
   end
 
 end

--- a/rojak-api/web/models/news.ex
+++ b/rojak-api/web/models/news.ex
@@ -1,6 +1,9 @@
 defmodule RojakAPI.News do
   use RojakAPI.Web, :model
 
+  # Self-alias
+  alias RojakAPI.News
+
   schema "news" do
     field :title, :string
     field :url, :string
@@ -12,6 +15,20 @@ defmodule RojakAPI.News do
     many_to_many :mentions, RojakAPI.Candidate, join_through: "mention"
 
     timestamps()
+  end
+
+  def fetch(%{limit: limit, offset: offset, embed: embed, media_id: media_id, candidate_id: candidate_id}) do
+    query = from n in News,
+      limit: ^limit,
+      offset: ^offset,
+      order_by: [desc: n.id]
+    query
+    |> Repo.all
+  end
+
+  def fetch_one(%{id: id, embed: embed}) do
+    News
+    |> Repo.get!(id)
   end
 
 end

--- a/rojak-api/web/models/pair_of_candidates.ex
+++ b/rojak-api/web/models/pair_of_candidates.ex
@@ -21,4 +21,30 @@ defmodule RojakAPI.PairOfCandidates do
     timestamps()
   end
 
+  def fetch_embed(query, embed) do
+    case embed do
+      nil ->
+        query
+      _ ->
+        query
+        |> fetch_candidates(embed_by?(embed, "candidates"))
+    end
+  end
+
+  defp fetch_candidates(query, should_embed?) do
+    case should_embed? do
+      false ->
+        query
+      true ->
+        from q in query,
+          join: cagub in assoc(q, :cagub),
+          join: cawagub in assoc(q, :cawagub),
+          preload: [cagub: cagub, cawagub: cawagub]
+    end
+  end
+
+  defp embed_by?(embed, key) do
+    Enum.member?(embed, key)
+  end
+
 end

--- a/rojak-api/web/params_validator.ex
+++ b/rojak-api/web/params_validator.ex
@@ -1,4 +1,4 @@
-defmodule RojakAPI.V1.ParamsValidator do
+defmodule RojakAPI.ParamsValidator do
   @moduledoc """
   Utility module for validating request params.
   """
@@ -20,12 +20,12 @@ defmodule RojakAPI.V1.ParamsValidator do
     #    message: "invalid parameters provided"
     #  }
     #end
-  end
 
-  # Handle InvalidParamsError as 422.
-  # REVIEW: should this be put here?
-  defimpl Plug.Exception, for: InvalidParamsError do
-    def status(_exception), do: 422
+    # Handle InvalidParamsError as 422.
+    defimpl Plug.Exception, for: InvalidParamsError do
+      def status(_exception), do: 422
+    end
+
   end
 
   @doc """

--- a/rojak-api/web/router.ex
+++ b/rojak-api/web/router.ex
@@ -11,6 +11,8 @@ defmodule RojakAPI.Router do
     get "/", IndexController, :index
 
     scope "/v1", V1, as: :v1 do
+      get "/pairings", PairingController, :index
+      get "/pairings/:id", PairingController, :show
       get "/candidates", CandidateController, :index
       get "/candidates/:id", CandidateController, :show
       get "/media", MediaController, :index

--- a/rojak-api/web/router.ex
+++ b/rojak-api/web/router.ex
@@ -15,6 +15,8 @@ defmodule RojakAPI.Router do
       get "/pairings/:id", PairingController, :show
       get "/candidates", CandidateController, :index
       get "/candidates/:id", CandidateController, :show
+      get "/news", NewsController, :index
+      get "/news/:id", NewsController, :show
       get "/media", MediaController, :index
       get "/media/:id", MediaController, :show
     end

--- a/rojak-api/web/router.ex
+++ b/rojak-api/web/router.ex
@@ -11,6 +11,8 @@ defmodule RojakAPI.Router do
     get "/", IndexController, :index
 
     scope "/v1", V1, as: :v1 do
+      get "/candidates", CandidateController, :index
+      get "/candidates/:id", CandidateController, :show
       get "/media", MediaController, :index
       get "/media/:id", MediaController, :show
     end

--- a/rojak-api/web/v1/candidate/candidate_controller.ex
+++ b/rojak-api/web/v1/candidate/candidate_controller.ex
@@ -1,0 +1,18 @@
+defmodule RojakAPI.V1.CandidateController do
+  use RojakAPI.Web, :controller
+
+  alias RojakAPI.Candidate
+
+  # TODO: also load sentiments and pairing if `embed` parameter is set
+
+  def index(conn, _params) do
+    candidates = Repo.all(Candidate)
+    render(conn, "index.json", candidates: candidates)
+  end
+
+  def show(conn, %{"id" => id}) do
+    candidate = Repo.get!(Candidate, id)
+    render(conn, "show.json", candidate: candidate)
+  end
+
+end

--- a/rojak-api/web/v1/candidate/candidate_controller.ex
+++ b/rojak-api/web/v1/candidate/candidate_controller.ex
@@ -3,8 +3,6 @@ defmodule RojakAPI.V1.CandidateController do
 
   alias RojakAPI.Candidate
 
-  # TODO: also load sentiments and pairing if `embed` parameter is set
-
   defparams candidate_index_params(%{
     embed: [:string],
   }) do
@@ -16,8 +14,7 @@ defmodule RojakAPI.V1.CandidateController do
 
   def index(conn, params) do
     validated_params = ParamsValidator.validate params, &candidate_index_params/1
-    %{embed: embed} = validated_params
-    candidates = Repo.all(Candidate)
+    candidates = Candidate.fetch(validated_params)
     render(conn, "index.json", candidates: candidates)
   end
 
@@ -31,10 +28,9 @@ defmodule RojakAPI.V1.CandidateController do
     end
   end
 
-  def show(conn, %{"id" => id} = params) do
+  def show(conn, params) do
     validated_params = ParamsValidator.validate params, &candidate_show_params/1
-    %{embed: embed} = validated_params
-    candidate = Repo.get!(Candidate, id)
+    candidate = Candidate.fetch_one(validated_params)
     render(conn, "show.json", candidate: candidate)
   end
 

--- a/rojak-api/web/v1/candidate/candidate_controller.ex
+++ b/rojak-api/web/v1/candidate/candidate_controller.ex
@@ -5,12 +5,35 @@ defmodule RojakAPI.V1.CandidateController do
 
   # TODO: also load sentiments and pairing if `embed` parameter is set
 
-  def index(conn, _params) do
+  defparams candidate_index_params(%{
+    embed: [:string],
+  }) do
+    def changeset(ch, params) do
+      cast(ch, params, [:embed])
+      |> validate_subset(:embed, ["sentiments"])
+    end
+  end
+
+  def index(conn, params) do
+    validated_params = ParamsValidator.validate params, &candidate_index_params/1
+    %{embed: embed} = validated_params
     candidates = Repo.all(Candidate)
     render(conn, "index.json", candidates: candidates)
   end
 
-  def show(conn, %{"id" => id}) do
+  defparams candidate_show_params(%{
+    id!: :integer,
+    embed: [:string],
+  }) do
+    def changeset(ch, params) do
+      cast(ch, params, [:id, :embed])
+      |> validate_subset(:embed, ["sentiments", "pairing"])
+    end
+  end
+
+  def show(conn, %{"id" => id} = params) do
+    validated_params = ParamsValidator.validate params, &candidate_show_params/1
+    %{embed: embed} = validated_params
     candidate = Repo.get!(Candidate, id)
     render(conn, "show.json", candidate: candidate)
   end

--- a/rojak-api/web/v1/candidate/candidate_view.ex
+++ b/rojak-api/web/v1/candidate/candidate_view.ex
@@ -1,8 +1,6 @@
 defmodule RojakAPI.V1.CandidateView do
   use RojakAPI.Web, :view
 
-  # TODO: enable embedding sentiments and pairing
-
   def render("index.json", %{candidates: candidates}) do
     render_many(candidates, RojakAPI.V1.CandidateView, "candidate.json")
   end
@@ -12,6 +10,18 @@ defmodule RojakAPI.V1.CandidateView do
   end
 
   def render("candidate.json", %{candidate: candidate}) do
-    Map.drop candidate, [:__meta__, :mentioned_in, :sentiments]
+    candidate =
+      candidate
+      |> Map.drop([:__meta__, :mentioned_in, :sentiments])
+
+    # Embed pairing
+    candidate = case Map.get(candidate, :pairing) do
+      nil ->
+        candidate
+      pairing ->
+        Map.update!(candidate, :pairing, fn _ -> Map.drop(pairing, [:__meta__, :cagub, :cawagub]) end)
+    end
+
+    candidate
   end
 end

--- a/rojak-api/web/v1/candidate/candidate_view.ex
+++ b/rojak-api/web/v1/candidate/candidate_view.ex
@@ -1,0 +1,17 @@
+defmodule RojakAPI.V1.CandidateView do
+  use RojakAPI.Web, :view
+
+  # TODO: enable embedding sentiments and pairing
+
+  def render("index.json", %{candidates: candidates}) do
+    render_many(candidates, RojakAPI.V1.CandidateView, "candidate.json")
+  end
+
+  def render("show.json", %{candidate: candidate}) do
+    render_one(candidate, RojakAPI.V1.CandidateView, "candidate.json")
+  end
+
+  def render("candidate.json", %{candidate: candidate}) do
+    Map.drop candidate, [:__meta__, :mentioned_in, :sentiments]
+  end
+end

--- a/rojak-api/web/v1/candidate/candidate_view.ex
+++ b/rojak-api/web/v1/candidate/candidate_view.ex
@@ -17,7 +17,7 @@ defmodule RojakAPI.V1.CandidateView do
     # Embed pairing
     candidate = case Map.get(candidate, :pairing) do
       nil ->
-        candidate
+        candidate |> Map.drop([:pairing])
       pairing ->
         Map.update! candidate, :pairing, fn _ ->
           Map.drop(pairing, [:__meta__, :cagub, :cawagub])

--- a/rojak-api/web/v1/candidate/candidate_view.ex
+++ b/rojak-api/web/v1/candidate/candidate_view.ex
@@ -19,7 +19,9 @@ defmodule RojakAPI.V1.CandidateView do
       nil ->
         candidate
       pairing ->
-        Map.update!(candidate, :pairing, fn _ -> Map.drop(pairing, [:__meta__, :cagub, :cawagub]) end)
+        Map.update! candidate, :pairing, fn _ ->
+          Map.drop(pairing, [:__meta__, :cagub, :cawagub])
+        end
     end
 
     candidate

--- a/rojak-api/web/v1/media/media_controller.ex
+++ b/rojak-api/web/v1/media/media_controller.ex
@@ -10,17 +10,17 @@ defmodule RojakAPI.V1.MediaController do
 
   def index(conn, params) do
     validated_params = ParamsValidator.validate params, &media_index_params/1
-    %{limit: limit, offset: offset} = validated_params
-    media = Repo.all(
-      from Media,
-        limit: ^limit,
-        offset: ^offset
-    )
+    media = Media.fetch(validated_params)
     render(conn, "index.json", media: media)
   end
 
-  def show(conn, %{"id" => id}) do
-    media = Repo.get!(Media, id)
+  defparams media_show_params %{
+    id!: :integer,
+  }
+
+  def show(conn, params) do
+    validated_params = ParamsValidator.validate params, &media_show_params/1
+    media = Media.fetch_one(validated_params)
     render(conn, "show.json", media: media)
   end
 

--- a/rojak-api/web/v1/media/media_controller.ex
+++ b/rojak-api/web/v1/media/media_controller.ex
@@ -1,11 +1,18 @@
 defmodule RojakAPI.V1.MediaController do
   use RojakAPI.Web, :controller
+  use Params
 
   alias RojakAPI.Media
+  alias RojakAPI.V1.ParamsValidator
+
+  defparams index_params %{
+    limit: [field: :integer, default: 10],
+    offset: [field: :integer, default: 0],
+  }
 
   def index(conn, params) do
-    limit = Dict.get(params, "limit", 10)
-    offset = Dict.get(params, "offset", 0)
+    validated_params = ParamsValidator.validate params, &index_params/1
+    %{limit: limit, offset: offset} = validated_params
     media = Repo.all(
       from Media,
         limit: ^limit,

--- a/rojak-api/web/v1/media/media_controller.ex
+++ b/rojak-api/web/v1/media/media_controller.ex
@@ -1,9 +1,7 @@
 defmodule RojakAPI.V1.MediaController do
   use RojakAPI.Web, :controller
-  use Params
 
   alias RojakAPI.Media
-  alias RojakAPI.V1.ParamsValidator
 
   defparams media_index_params %{
     limit: [field: :integer, default: 10],

--- a/rojak-api/web/v1/media/media_controller.ex
+++ b/rojak-api/web/v1/media/media_controller.ex
@@ -3,8 +3,14 @@ defmodule RojakAPI.V1.MediaController do
 
   alias RojakAPI.Media
 
-  def index(conn, _params) do
-    media = Repo.all(Media)
+  def index(conn, params) do
+    limit = Dict.get(params, "limit", 10)
+    offset = Dict.get(params, "offset", 0)
+    media = Repo.all(
+      from Media,
+        limit: ^limit,
+        offset: ^offset
+    )
     render(conn, "index.json", media: media)
   end
 

--- a/rojak-api/web/v1/media/media_controller.ex
+++ b/rojak-api/web/v1/media/media_controller.ex
@@ -5,13 +5,13 @@ defmodule RojakAPI.V1.MediaController do
   alias RojakAPI.Media
   alias RojakAPI.V1.ParamsValidator
 
-  defparams index_params %{
+  defparams media_index_params %{
     limit: [field: :integer, default: 10],
     offset: [field: :integer, default: 0],
   }
 
   def index(conn, params) do
-    validated_params = ParamsValidator.validate params, &index_params/1
+    validated_params = ParamsValidator.validate params, &media_index_params/1
     %{limit: limit, offset: offset} = validated_params
     media = Repo.all(
       from Media,

--- a/rojak-api/web/v1/media/media_view.ex
+++ b/rojak-api/web/v1/media/media_view.ex
@@ -10,14 +10,6 @@ defmodule RojakAPI.V1.MediaView do
   end
 
   def render("media.json", %{media: media}) do
-    %{
-      "id": media.id,
-      "name": media.name,
-      "website_url": media.website_url,
-      "logo_url": media.logo_url,
-      "fbpage_username": media.fbpage_username,
-      "twitter_username": media.twitter_username,
-      "instagram_username": media.instagram_username,
-    }
+    Map.drop media, [:__meta__, :news]
   end
 end

--- a/rojak-api/web/v1/news/news_controller.ex
+++ b/rojak-api/web/v1/news/news_controller.ex
@@ -3,8 +3,6 @@ defmodule RojakAPI.V1.NewsController do
 
   alias RojakAPI.News
 
-  # TODO: also load mentions if `embed` parameter is set
-
   defparams news_index_params(%{
     limit: [field: :integer, default: 10],
     offset: [field: :integer, default: 0],
@@ -20,14 +18,7 @@ defmodule RojakAPI.V1.NewsController do
 
   def index(conn, params) do
     validated_params = ParamsValidator.validate params, &news_index_params/1
-    %{limit: limit, offset: offset, embed: embed,
-      media_id: media_id, candidate_id: candidate_id} = validated_params
-    news = Repo.all(
-      from n in News,
-        limit: ^limit,
-        offset: ^offset,
-        order_by: [desc: n.id]
-    )
+    news = News.fetch(validated_params)
     render(conn, "index.json", news: news)
   end
 
@@ -41,10 +32,9 @@ defmodule RojakAPI.V1.NewsController do
     end
   end
 
-  def show(conn, %{"id" => id} = params) do
+  def show(conn, params) do
     validated_params = ParamsValidator.validate params, &news_show_params/1
-    %{embed: embed} = validated_params
-    news = Repo.get!(News, id)
+    news = News.fetch_one(validated_params)
     render(conn, "show.json", news: news)
   end
 

--- a/rojak-api/web/v1/news/news_controller.ex
+++ b/rojak-api/web/v1/news/news_controller.ex
@@ -1,12 +1,26 @@
 defmodule RojakAPI.V1.NewsController do
   use RojakAPI.Web, :controller
+  use Params
 
   alias RojakAPI.News
+  alias RojakAPI.V1.ParamsValidator
 
   # TODO: also load mentions if `embed` parameter is set
 
-  def index(conn, _params) do
-    news = Repo.all(News)
+  defparams news_index_params %{
+    limit: [field: :integer, default: 10],
+    offset: [field: :integer, default: 0],
+  }
+
+  def index(conn, params) do
+    validated_params = ParamsValidator.validate params, &news_index_params/1
+    %{limit: limit, offset: offset} = validated_params
+    news = Repo.all(
+      from n in News,
+        limit: ^limit,
+        offset: ^offset,
+        order_by: [desc: n.id]
+    )
     render(conn, "index.json", news: news)
   end
 

--- a/rojak-api/web/v1/news/news_controller.ex
+++ b/rojak-api/web/v1/news/news_controller.ex
@@ -5,14 +5,23 @@ defmodule RojakAPI.V1.NewsController do
 
   # TODO: also load mentions if `embed` parameter is set
 
-  defparams news_index_params %{
+  defparams news_index_params(%{
     limit: [field: :integer, default: 10],
     offset: [field: :integer, default: 0],
-  }
+    embed: [:string],
+    media_id: [:integer],
+    candidate_id: [:integer]
+  }) do
+    def changeset(ch, params) do
+      cast(ch, params, [:limit, :offset, :embed, :media_id, :candidate_id])
+      |> validate_subset(:embed, ["mentions"])
+    end
+  end
 
   def index(conn, params) do
     validated_params = ParamsValidator.validate params, &news_index_params/1
-    %{limit: limit, offset: offset} = validated_params
+    %{limit: limit, offset: offset, embed: embed,
+      media_id: media_id, candidate_id: candidate_id} = validated_params
     news = Repo.all(
       from n in News,
         limit: ^limit,
@@ -22,7 +31,19 @@ defmodule RojakAPI.V1.NewsController do
     render(conn, "index.json", news: news)
   end
 
-  def show(conn, %{"id" => id}) do
+  defparams news_show_params(%{
+    id!: :integer,
+    embed: [:string],
+  }) do
+    def changeset(ch, params) do
+      cast(ch, params, [:id, :embed])
+      |> validate_subset(:embed, ["mentions"])
+    end
+  end
+
+  def show(conn, %{"id" => id} = params) do
+    validated_params = ParamsValidator.validate params, &news_show_params/1
+    %{embed: embed} = validated_params
     news = Repo.get!(News, id)
     render(conn, "show.json", news: news)
   end

--- a/rojak-api/web/v1/news/news_controller.ex
+++ b/rojak-api/web/v1/news/news_controller.ex
@@ -1,9 +1,7 @@
 defmodule RojakAPI.V1.NewsController do
   use RojakAPI.Web, :controller
-  use Params
 
   alias RojakAPI.News
-  alias RojakAPI.V1.ParamsValidator
 
   # TODO: also load mentions if `embed` parameter is set
 

--- a/rojak-api/web/v1/news/news_controller.ex
+++ b/rojak-api/web/v1/news/news_controller.ex
@@ -1,0 +1,18 @@
+defmodule RojakAPI.V1.NewsController do
+  use RojakAPI.Web, :controller
+
+  alias RojakAPI.News
+
+  # TODO: also load mentions if `embed` parameter is set
+
+  def index(conn, _params) do
+    news = Repo.all(News)
+    render(conn, "index.json", news: news)
+  end
+
+  def show(conn, %{"id" => id}) do
+    news = Repo.get!(News, id)
+    render(conn, "show.json", news: news)
+  end
+
+end

--- a/rojak-api/web/v1/news/news_view.ex
+++ b/rojak-api/web/v1/news/news_view.ex
@@ -10,6 +10,22 @@ defmodule RojakAPI.V1.NewsView do
   end
 
   def render("news.json", %{news: news}) do
-    Map.drop news, [:__meta__, :media, :sentiments, :mentions]
+    news =
+      news
+      |> Map.drop([:__meta__, :media, :sentiments, :mentioned_candidates])
+
+    # Embed mentions
+    news = case Map.get(news, :mentions) do
+      %Ecto.Association.NotLoaded{} ->
+        news |> Map.drop([:mentions])
+      mentions ->
+        Map.update! news, :mentions, fn _ ->
+          Enum.map mentions, fn mention ->
+            Map.drop(mention, [:__meta__, :mentioned_in, :sentiments])
+          end
+        end
+    end
+
+    news
   end
 end

--- a/rojak-api/web/v1/news/news_view.ex
+++ b/rojak-api/web/v1/news/news_view.ex
@@ -1,0 +1,15 @@
+defmodule RojakAPI.V1.NewsView do
+  use RojakAPI.Web, :view
+
+  def render("index.json", %{news: news}) do
+    render_many(news, RojakAPI.V1.NewsView, "news.json")
+  end
+
+  def render("show.json", %{news: news}) do
+    render_one(news, RojakAPI.V1.NewsView, "news.json")
+  end
+
+  def render("news.json", %{news: news}) do
+    Map.drop news, [:__meta__, :media, :sentiments, :mentions]
+  end
+end

--- a/rojak-api/web/v1/pairing/pairing_controller.ex
+++ b/rojak-api/web/v1/pairing/pairing_controller.ex
@@ -16,8 +16,7 @@ defmodule RojakAPI.V1.PairingController do
 
   def index(conn, params) do
     validated_params = ParamsValidator.validate params, &pairing_index_params/1
-    %{embed: embed} = validated_params
-    pairings = Repo.all(PairOfCandidates)
+    pairings = PairOfCandidates.fetch(validated_params)
     render(conn, "index.json", pairings: pairings)
   end
 
@@ -31,13 +30,9 @@ defmodule RojakAPI.V1.PairingController do
     end
   end
 
-  def show(conn, %{"id" => id} = params) do
+  def show(conn, params) do
     validated_params = ParamsValidator.validate params, &pairing_show_params/1
-    %{embed: embed} = validated_params
-    pairing =
-      PairOfCandidates
-      |> PairOfCandidates.fetch_embed(embed)
-      |> Repo.get!(id)
+    pairing = PairOfCandidates.fetch_one(validated_params)
     render(conn, "show.json", pairing: pairing)
   end
 

--- a/rojak-api/web/v1/pairing/pairing_controller.ex
+++ b/rojak-api/web/v1/pairing/pairing_controller.ex
@@ -1,0 +1,18 @@
+defmodule RojakAPI.V1.PairingController do
+  use RojakAPI.Web, :controller
+
+  alias RojakAPI.PairOfCandidates
+
+  # TODO: also load sentiments and candidates if `embed` parameter is set
+
+  def index(conn, _params) do
+    pairings = Repo.all(PairOfCandidates)
+    render(conn, "index.json", pairings: pairings)
+  end
+
+  def show(conn, %{"id" => id}) do
+    pairing = Repo.get!(PairOfCandidates, id)
+    render(conn, "show.json", pairing: pairing)
+  end
+
+end

--- a/rojak-api/web/v1/pairing/pairing_controller.ex
+++ b/rojak-api/web/v1/pairing/pairing_controller.ex
@@ -34,7 +34,10 @@ defmodule RojakAPI.V1.PairingController do
   def show(conn, %{"id" => id} = params) do
     validated_params = ParamsValidator.validate params, &pairing_show_params/1
     %{embed: embed} = validated_params
-    pairing = Repo.get!(PairOfCandidates, id)
+    pairing =
+      PairOfCandidates
+      |> PairOfCandidates.fetch_embed(embed)
+      |> Repo.get!(id)
     render(conn, "show.json", pairing: pairing)
   end
 

--- a/rojak-api/web/v1/pairing/pairing_controller.ex
+++ b/rojak-api/web/v1/pairing/pairing_controller.ex
@@ -5,12 +5,35 @@ defmodule RojakAPI.V1.PairingController do
 
   # TODO: also load sentiments and candidates if `embed` parameter is set
 
-  def index(conn, _params) do
+  defparams pairing_index_params(%{
+    embed: [:string],
+  }) do
+    def changeset(ch, params) do
+      cast(ch, params, [:embed])
+      |> validate_subset(:embed, ["sentiments"])
+    end
+  end
+
+  def index(conn, params) do
+    validated_params = ParamsValidator.validate params, &pairing_index_params/1
+    %{embed: embed} = validated_params
     pairings = Repo.all(PairOfCandidates)
     render(conn, "index.json", pairings: pairings)
   end
 
-  def show(conn, %{"id" => id}) do
+  defparams pairing_show_params(%{
+    id!: :integer,
+    embed: [:string],
+  }) do
+    def changeset(ch, params) do
+      cast(ch, params, [:id, :embed])
+      |> validate_subset(:embed, ["sentiments", "candidates"])
+    end
+  end
+
+  def show(conn, %{"id" => id} = params) do
+    validated_params = ParamsValidator.validate params, &pairing_show_params/1
+    %{embed: embed} = validated_params
     pairing = Repo.get!(PairOfCandidates, id)
     render(conn, "show.json", pairing: pairing)
   end

--- a/rojak-api/web/v1/pairing/pairing_view.ex
+++ b/rojak-api/web/v1/pairing/pairing_view.ex
@@ -1,0 +1,17 @@
+defmodule RojakAPI.V1.PairingView do
+  use RojakAPI.Web, :view
+
+  # TODO: enable embedding sentiments and candidate
+
+  def render("index.json", %{pairings: pairings}) do
+    render_many(pairings, RojakAPI.V1.PairingView, "pairing.json")
+  end
+
+  def render("show.json", %{pairing: pairing}) do
+    render_one(pairing, RojakAPI.V1.PairingView, "pairing.json")
+  end
+
+  def render("pairing.json", %{pairing: pairing}) do
+    Map.drop pairing, [:__meta__, :cagub, :cawagub]
+  end
+end

--- a/rojak-api/web/v1/pairing/pairing_view.ex
+++ b/rojak-api/web/v1/pairing/pairing_view.ex
@@ -1,8 +1,6 @@
 defmodule RojakAPI.V1.PairingView do
   use RojakAPI.Web, :view
 
-  # TODO: enable embedding sentiments and candidate
-
   def render("index.json", %{pairings: pairings}) do
     render_many(pairings, RojakAPI.V1.PairingView, "pairing.json")
   end
@@ -19,7 +17,7 @@ defmodule RojakAPI.V1.PairingView do
     # Embed candidates
     pairing = case Map.get(pairing, :candidates) do
       nil ->
-        pairing
+        pairing |> Map.drop([:candidates])
       %{cagub: cagub, cawagub: cawagub} ->
         Map.update! pairing, :candidates, fn _ ->
           %{

--- a/rojak-api/web/v1/pairing/pairing_view.ex
+++ b/rojak-api/web/v1/pairing/pairing_view.ex
@@ -14,19 +14,20 @@ defmodule RojakAPI.V1.PairingView do
   def render("pairing.json", %{pairing: pairing}) do
     pairing =
       pairing
-      |> Map.drop([:__meta__])
+      |> Map.drop([:__meta__, :cagub, :cawagub])
 
     # Embed candidates
-    pairing = cond do
-      Ecto.assoc_loaded?(pairing.cagub) and Ecto.assoc_loaded?(pairing.cawagub) ->
+    pairing = case Map.get(pairing, :candidates) do
+      nil ->
         pairing
-        |> Map.put(:candidates, %{
-            cagub: Map.drop(pairing.cagub, [:__meta__, :mentioned_in, :sentiments]),
-            cawagub: Map.drop(pairing.cawagub, [:__meta__, :mentioned_in, :sentiments]),
-          })
-      true ->
-        pairing
-    end |> Map.drop([:cagub, :cawagub])
+      %{cagub: cagub, cawagub: cawagub} ->
+        Map.update! pairing, :candidates, fn _ ->
+          %{
+            cagub: Map.drop(cagub, [:__meta__, :mentioned_in, :sentiments]),
+            cawagub: Map.drop(cawagub, [:__meta__, :mentioned_in, :sentiments]),
+          }
+        end
+    end
 
     pairing
   end

--- a/rojak-api/web/v1/pairing/pairing_view.ex
+++ b/rojak-api/web/v1/pairing/pairing_view.ex
@@ -12,6 +12,22 @@ defmodule RojakAPI.V1.PairingView do
   end
 
   def render("pairing.json", %{pairing: pairing}) do
-    Map.drop pairing, [:__meta__, :cagub, :cawagub]
+    pairing =
+      pairing
+      |> Map.drop([:__meta__])
+
+    # Embed candidates
+    pairing = cond do
+      Ecto.assoc_loaded?(pairing.cagub) and Ecto.assoc_loaded?(pairing.cawagub) ->
+        pairing
+        |> Map.put(:candidates, %{
+            cagub: Map.drop(pairing.cagub, [:__meta__, :mentioned_in, :sentiments]),
+            cawagub: Map.drop(pairing.cawagub, [:__meta__, :mentioned_in, :sentiments]),
+          })
+      true ->
+        pairing
+    end |> Map.drop([:cagub, :cawagub])
+
+    pairing
   end
 end

--- a/rojak-api/web/v1/params_validator.ex
+++ b/rojak-api/web/v1/params_validator.ex
@@ -1,0 +1,47 @@
+defmodule RojakAPI.V1.ParamsValidator do
+  @moduledoc """
+  Utility module for validating request params.
+  """
+
+  defmodule InvalidParamsError do
+    @moduledoc """
+    Exception raised when params validation failed.
+    """
+
+    defexception plug_status: :unprocessable_entity,
+      message: "invalid parameters provided",
+      params_errors: nil
+
+    # We can improve the error message by providing
+    # the error messages from the changeset.
+    #def exception(_opts) do
+    #  params_errors = Keyword.fetch!(opts, :params_errors)
+    #  %InvalidParamsError{
+    #    message: "invalid parameters provided"
+    #  }
+    #end
+  end
+
+  # Handle InvalidParamsError as 422.
+  # REVIEW: should this be put here?
+  defimpl Plug.Exception, for: InvalidParamsError do
+    def status(_exception), do: 422
+  end
+
+  @doc """
+  Validate params based on rules function. This function will raise
+  `InvalidParamsError` when changeset test fails.
+
+  `rules` is a Params definition. See: https://github.com/vic/params
+  """
+  def validate(params, rules) do
+    changeset = rules.(params)
+    cond do
+      changeset.valid? ->
+        Params.data changeset
+      true ->
+        raise InvalidParamsError
+    end
+  end
+
+end

--- a/rojak-api/web/web.ex
+++ b/rojak-api/web/web.ex
@@ -29,6 +29,7 @@ defmodule RojakAPI.Web do
   def controller do
     quote do
       use Phoenix.Controller, namespace: RojakAPI
+      use Params
 
       alias RojakAPI.Repo
       import Ecto
@@ -36,6 +37,8 @@ defmodule RojakAPI.Web do
 
       import RojakAPI.Router.Helpers
       import RojakAPI.Gettext
+
+      alias RojakAPI.V1.ParamsValidator
     end
   end
 

--- a/rojak-api/web/web.ex
+++ b/rojak-api/web/web.ex
@@ -34,6 +34,7 @@ defmodule RojakAPI.Web do
       alias RojakAPI.Repo
       import Ecto
       import Ecto.Query
+      import Ecto.Changeset
 
       import RojakAPI.Router.Helpers
       import RojakAPI.Gettext

--- a/rojak-api/web/web.ex
+++ b/rojak-api/web/web.ex
@@ -41,7 +41,7 @@ defmodule RojakAPI.Web do
       import RojakAPI.Router.Helpers
       import RojakAPI.Gettext
 
-      alias RojakAPI.V1.ParamsValidator
+      alias RojakAPI.ParamsValidator
     end
   end
 

--- a/rojak-api/web/web.ex
+++ b/rojak-api/web/web.ex
@@ -23,6 +23,8 @@ defmodule RojakAPI.Web do
       import Ecto
       import Ecto.Changeset
       import Ecto.Query
+
+      alias RojakAPI.Repo
     end
   end
 


### PR DESCRIPTION
Implementasi API untuk spesifikasi API v0.2. Implementasi masih kurang semua yang berhubungan dengan sentiment. Tepatnya, endpoint-endpoint ini belum bekerja dengan baik:
1. `/pairing?embed[]=sentiments`
2. `/pairing/1?embed[]=sentiments`
3. `/pairing/1/media-sentiments`
4. `/candidate?embed[]=sentiments`
5. `/candidate/1?embed[]=sentiments`
6. `/candidate/1/media-sentiments`
7.  `/news?embed[]=mentions` (belum menginclude sentimen dari mention)
8.  `/news/1?embed[]=mentions` (belum menginclude sentimen dari mention)
9. `/media/1/sentiments`

Sisanya seharusnya sudah berjalan. Sudah dibuat tests juga. Mengingat query untuk sentiment masih blocking di #126, mungkin ini bisa dimerge dulu?
