### PR TITLE
[rojak-api] Bump to v0.1.0, rename docker image

### DIFF
--- a/rojak-api/README.md
+++ b/rojak-api/README.md
@@ -58,7 +58,7 @@ Berikut adalah step untuk melakukan build image production:
     ```
     $ ./build-release.sh 1.0.0
     ```
-3. Perintah tersebut akan menghasilkan sebuah docker image bernama `rojak/rojak-api` dengan tag sesuai version yang siap untuk dijalankan.
+3. Perintah tersebut akan menghasilkan sebuah docker image bernama `rojakid/rojak-api` dengan tag sesuai version yang siap untuk dijalankan.
 
 ### Usage
 
@@ -69,5 +69,5 @@ $ docker run -p [port]:4000 \
     -e DB_PASSWORD=[db_password] \
     -e DB_NAME=[db_name] \
     -e DB_HOST=[db_host] \
-    rojak/rojak-api:[tag]
+    rojakid/rojak-api:[tag]
 ```

--- a/rojak-api/README.md
+++ b/rojak-api/README.md
@@ -6,7 +6,7 @@ API untuk komunikasi antara rojak-ui-* dengan rojak-database.
 |-------------------|--------|
 | Schema Data       | v0.4   |
 | API Specification | v0.2   |
-| App               | v0.0.1 |
+| App               | v0.1.0 |
 
 ## Development
 
@@ -71,3 +71,13 @@ $ docker run -p [port]:4000 \
     -e DB_HOST=[db_host] \
     rojakid/rojak-api:[tag]
 ```
+
+## Changelog
+
+### 0.1.0
+
+- Implementasi API spec v0.2 tanpa sentiment
+
+### 0.0.1
+
+- Inisialisasi Phoenix project

--- a/rojak-api/build-release.sh
+++ b/rojak-api/build-release.sh
@@ -17,4 +17,4 @@ docker-compose -f docker-compose.build.yml run --rm --no-deps \
       -e MIX_ENV=prod builder mix release --env=prod
 
 # Build the docker container
-docker build --build-arg VERSION=$VERSION -t rojak/rojak-api:$VERSION .
+docker build --build-arg VERSION=$VERSION -t rojakid/rojak-api:$VERSION .

--- a/rojak-api/mix.exs
+++ b/rojak-api/mix.exs
@@ -3,7 +3,7 @@ defmodule RojakAPI.Mixfile do
 
   def project do
     [app: :rojak_api,
-     version: "0.0.1",
+     version: "0.1.0",
      elixir: "~> 1.2",
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:phoenix, :gettext] ++ Mix.compilers,


### PR DESCRIPTION
Mengubah docker image dari `rojak/rojak-api` ke `rojakid/rojak-api` karena namespace `rojak` sudah dipakai.

Saat ini image v0.1.0 sudah ada di dockerhub: https://hub.docker.com/r/rojakid/rojak-api/

Instruksi penggunaan ada di README.md `rojak-api`.
