### PR TITLE
[rojak-api] Implementasi fetching sentiments

### DIFF
--- a/rojak-api/README.md
+++ b/rojak-api/README.md
@@ -6,7 +6,7 @@ API untuk komunikasi antara rojak-ui-* dengan rojak-database.
 |-------------------|--------|
 | Schema Data       | v0.4   |
 | API Specification | v0.2   |
-| App               | v0.1.0 |
+| App               | v0.2.0 |
 
 ## Development
 
@@ -79,7 +79,7 @@ Berikut adalah langkah untuk generate dokumentasi API:
 1. Pastikan [apiDoc](http://apidocjs.com/#getting-started) sudah terinstall.
 2. Untuk mengubah/menghapus/menambahkan dokumentasi API, dapat dilakukan di atas code handler masing-masing controller.
 3. ApiDoc akan men-generate semua comment paramater apidoc yang berada di dalam scope
-   
+
     ```
       @apidoc """
         comment parameter apidoc
@@ -88,13 +88,17 @@ Berikut adalah langkah untuk generate dokumentasi API:
 
 4. Parameter yang digunakan dapat dilihat di [sini](http://apidocjs.com/#params).
 5. Jalankan perintah ```apidoc -i web/v1/ -o spec/``` di terminal dari path `/rojak-api/`
-   
-   Perintah `-i web/v1/` akan mengambil input `@apiDoc` dari masing-masing controller di path `web/v1`. 
-   
+
+   Perintah `-i web/v1/` akan mengambil input `@apiDoc` dari masing-masing controller di path `web/v1`.
+
    Perintah `-o spec/` akan menaruh semua hasil output yang di-generate ke dalam direktori `spec/`
 6. Hasil generated doc dapat dilihat di file `spec/index.html`
 
 ## Changelog
+
+### 0.2.0
+
+- Implementasi fetching sentiments
 
 ### 0.1.0
 

--- a/rojak-api/mix.exs
+++ b/rojak-api/mix.exs
@@ -3,7 +3,7 @@ defmodule RojakAPI.Mixfile do
 
   def project do
     [app: :rojak_api,
-     version: "0.1.0",
+     version: "0.2.0",
      elixir: "~> 1.2",
      elixirc_paths: elixirc_paths(Mix.env),
      compilers: [:phoenix, :gettext] ++ Mix.compilers,

--- a/rojak-api/test/v1/candidate/candidate_controller_test.exs
+++ b/rojak-api/test/v1/candidate/candidate_controller_test.exs
@@ -38,7 +38,7 @@ defmodule RojakAPI.CandidateControllerTest do
     candidate_item = List.first(candidate_list)
     assert item_has_valid_properties?(candidate_item), "Item is missing valid properties."
 
-    # TODO: check if sentiments are embedded
+    assert Map.has_key?(candidate_item, "sentiments")
   end
 
   test "renders invalid parameters when trying to embed invalid field on index", %{conn: conn} do
@@ -58,7 +58,7 @@ defmodule RojakAPI.CandidateControllerTest do
     candidate_item = json_response(conn, 200)
     assert item_has_valid_properties?(candidate_item), "Item is missing valid properties."
 
-    # TODO: check if sentiments are embedded
+    assert Map.has_key?(candidate_item, "sentiments")
     assert Map.has_key?(candidate_item, "pairing")
   end
 
@@ -72,6 +72,15 @@ defmodule RojakAPI.CandidateControllerTest do
     assert_error_sent 404, fn ->
       get conn, v1_candidate_path(conn, :show, -1)
     end
+  end
+
+  test "list media with their sentiments on :media_sentiments", %{conn: conn} do
+    conn = get conn, v1_candidate_path(conn, :media_sentiments, 1)
+    media_sentiment_list = json_response(conn, 200)
+    assert Enum.count(media_sentiment_list) >= 0
+
+    media_sentiment_item = List.first(media_sentiment_list)
+    assert Map.has_key?(media_sentiment_item, "sentiments")
   end
 
   defp item_has_valid_properties?(item) do

--- a/rojak-api/test/v1/media/media_controller_test.exs
+++ b/rojak-api/test/v1/media/media_controller_test.exs
@@ -72,6 +72,28 @@ defmodule RojakAPI.MediaControllerTest do
     end
   end
 
+  test "list sentiments of the candidates on :sentiments", %{conn: conn} do
+    conn = get conn, v1_media_path(conn, :sentiments, 1)
+    sentiment_list = json_response(conn, 200)
+    assert Enum.count(sentiment_list) >= 0
+
+    sentiment_item = List.first(sentiment_list)
+    assert Map.has_key?(sentiment_item, "pairing")
+    assert Map.has_key?(sentiment_item, "candidates")
+
+    pairing = Map.get(sentiment_item, "pairing")
+    assert Map.has_key?(pairing, "sentiments")
+
+    candidates = Map.get(sentiment_item, "candidates")
+    assert Map.has_key?(candidates, "cagub")
+    assert Map.has_key?(candidates, "cawagub")
+
+    cagub = Map.get(candidates, "cagub")
+    cawagub = Map.get(candidates, "cawagub")
+    assert Map.has_key?(cagub, "sentiments")
+    assert Map.has_key?(cawagub, "sentiments")
+  end
+
   defp item_has_valid_properties?(item) do
     Enum.all?(@media_properties, &(Map.has_key?(item, &1)))
   end

--- a/rojak-api/test/v1/news/news_controller_test.exs
+++ b/rojak-api/test/v1/news/news_controller_test.exs
@@ -58,13 +58,13 @@ defmodule RojakAPI.NewsControllerTest do
     end
   end
 
-  test "allows embedding mentions on index", %{conn: conn} do
-    conn = get conn, v1_news_path(conn, :index), %{embed: ["mentions"]}
+  test "allows embedding sentiments on index", %{conn: conn} do
+    conn = get conn, v1_news_path(conn, :index), %{embed: ["sentiments"]}
     news_list = json_response(conn, 200)
     assert Enum.count(news_list) >= 0
 
     news_item = List.first(news_list)
-    assert Map.has_key?(news_item, "mentions")
+    assert Map.has_key?(news_item, "sentiments")
   end
 
   test "allows filtering by media id", %{conn: conn} do
@@ -86,14 +86,10 @@ defmodule RojakAPI.NewsControllerTest do
   end
 
   test "allows filtering by mentioned candidate id", %{conn: conn} do
-    conn = get conn, v1_news_path(conn, :index), %{candidate_id: ["1"], embed: ["mentions"]}
+    conn = get conn, v1_news_path(conn, :index), %{candidate_id: ["1"]}
     news_list = json_response(conn, 200)
-    assert Enum.all? news_list, fn news_item ->
-      mentions = Map.get(news_item, "mentions")
-      Enum.any? mentions, fn mentioned_candidate ->
-        Map.get(mentioned_candidate, "id") == 1
-      end
-    end
+    assert Enum.count(news_list) >= 0
+    # TODO: need to ensure the list contains only news mentioning the candidate
   end
 
   test "renders invalid parameters when candidate_id is not an array of integers", %{conn: conn} do
@@ -112,11 +108,11 @@ defmodule RojakAPI.NewsControllerTest do
     assert item_has_valid_properties?(news_item), "Item is missing valid properties."
   end
 
-  test "allows embedding mentions on show", %{conn: conn} do
-    conn = get conn, v1_news_path(conn, :show, 1), %{embed: ["mentions"]}
+  test "allows embedding sentiments on show", %{conn: conn} do
+    conn = get conn, v1_news_path(conn, :show, 1), %{embed: ["sentiments"]}
     news_item = json_response(conn, 200)
 
-    assert Map.has_key?(news_item, "mentions")
+    assert Map.has_key?(news_item, "sentiments")
   end
 
   test "renders page not found when id is nonexistent", %{conn: conn} do

--- a/rojak-api/test/v1/pairing/pairing_controller_test.exs
+++ b/rojak-api/test/v1/pairing/pairing_controller_test.exs
@@ -38,7 +38,7 @@ defmodule RojakAPI.PairingControllerTest do
     pairing_item = List.first(pairing_list)
     assert item_has_valid_properties?(pairing_item), "Item is missing valid properties."
 
-    # TODO: check if sentiments are embedded
+    assert Map.has_key?(pairing_item, "sentiments")
   end
 
   test "renders invalid parameters when trying to embed invalid field on index", %{conn: conn} do
@@ -58,7 +58,7 @@ defmodule RojakAPI.PairingControllerTest do
     pairing_item = json_response(conn, 200)
     assert item_has_valid_properties?(pairing_item), "Item is missing valid properties."
 
-    # TODO: check if sentiments are embedded
+    assert Map.has_key?(pairing_item, "sentiments")
     assert Map.has_key?(pairing_item, "candidates")
   end
 
@@ -72,6 +72,15 @@ defmodule RojakAPI.PairingControllerTest do
     assert_error_sent 404, fn ->
       get conn, v1_pairing_path(conn, :show, -1)
     end
+  end
+
+  test "list media with their sentiments on :media_sentiments", %{conn: conn} do
+    conn = get conn, v1_pairing_path(conn, :media_sentiments, 1)
+    media_sentiment_list = json_response(conn, 200)
+    assert Enum.count(media_sentiment_list) >= 0
+
+    media_sentiment_item = List.first(media_sentiment_list)
+    assert Map.has_key?(media_sentiment_item, "sentiments")
   end
 
   defp item_has_valid_properties?(item) do

--- a/rojak-api/web/models/candidate.ex
+++ b/rojak-api/web/models/candidate.ex
@@ -18,9 +18,10 @@ defmodule RojakAPI.Candidate do
 
     # Virtual fields for embedding joins
     field :pairing, :map, virtual: true
+    field :sentiments, :map, virtual: true
 
     # Relationship
-    has_many :sentiments, RojakAPI.Sentiment
+    # has_many :sentiments, RojakAPI.Sentiment
     many_to_many :mentioned_in, RojakAPI.News, join_through: "mention"
 
     timestamps()
@@ -42,13 +43,57 @@ defmodule RojakAPI.Candidate do
   defp fetch_embed(query, embed) do
     query
     |> fetch_pairing(Enum.member?(embed, "pairing"))
+    |> fetch_sentiments(Enum.member?(embed, "sentiments"))
+    |> select_embed_fields(embed)
+  end
+
+  defp select_embed_fields(query, embed) do
+    case [Enum.member?(embed, "pairing"), Enum.member?(embed, "sentiments")] do
+      [true, true] ->
+        from [q, p, s] in query,
+          select: %{q |
+            pairing: p,
+            sentiments: %{
+              positive: s.positive,
+              neutral: s.neutral,
+              negative: s.negative,
+            }
+          }
+      [true, _] ->
+        from [q, p] in query,
+          select: %{q | pairing: p}
+      [_, true] ->
+        from [q, s] in query,
+          select: %{q |
+            sentiments: %{
+              positive: s.positive,
+              neutral: s.neutral,
+              negative: s.negative,
+            }
+          }
+      _ -> query
+    end
   end
 
   defp fetch_pairing(query, embed?) when not embed?, do: query
   defp fetch_pairing(query, _) do
     from q in query,
-      join: p in RojakAPI.PairOfCandidates, on: q.id == p.cagub_id or q.id == p.cawagub_id,
-      select: %{q | pairing: p}
+      join: p in RojakAPI.PairOfCandidates, on: q.id == p.cagub_id or q.id == p.cawagub_id
+  end
+
+  defp fetch_sentiments(query, embed?) when not embed?, do: query
+  defp fetch_sentiments(query, _) do
+    from q in query,
+      join: s in fragment("""
+        SELECT
+          s.candidate_id,
+          COUNT(CASE WHEN s.name like 'pro%' THEN 1 END) positive,
+          COUNT(CASE WHEN s.name like 'net%' THEN 1 END) neutral,
+          COUNT(CASE WHEN s.name like 'con%' THEN 1 END) negative
+        FROM news_sentiment ns
+        JOIN sentiment s ON ns.sentiment_id = s.id
+        GROUP BY s.candidate_id
+        """), on: s.candidate_id == q.id
   end
 
 end

--- a/rojak-api/web/models/media.ex
+++ b/rojak-api/web/models/media.ex
@@ -29,4 +29,69 @@ defmodule RojakAPI.Media do
     |> Repo.get!(id)
   end
 
+  def fetch_sentiments(%{id: id}) do
+    query = from p in RojakAPI.PairOfCandidates,
+      join: cagub in assoc(p, :cagub),
+      join: cawagub in assoc(p, :cawagub),
+      join: cagub_sentiments in fragment("""
+        SELECT
+          s.candidate_id,
+          n.media_id,
+          COUNT(CASE WHEN s.name like 'pro%' THEN 1 END) positive,
+          COUNT(CASE WHEN s.name like 'net%' THEN 1 END) neutral,
+          COUNT(CASE WHEN s.name like 'con%' THEN 1 END) negative
+        FROM news_sentiment ns
+        JOIN news n ON ns.news_id = n.id
+        JOIN sentiment s ON ns.sentiment_id = s.id
+        GROUP BY s.candidate_id, n.media_id
+        """), on: cagub_sentiments.candidate_id == p.cawagub_id and cagub_sentiments.media_id == ^id,
+      join: cawagub_sentiments in fragment("""
+        SELECT
+          s.candidate_id,
+          n.media_id,
+          COUNT(CASE WHEN s.name like 'pro%' THEN 1 END) positive,
+          COUNT(CASE WHEN s.name like 'net%' THEN 1 END) neutral,
+          COUNT(CASE WHEN s.name like 'con%' THEN 1 END) negative
+        FROM news_sentiment ns
+        JOIN news n ON ns.news_id = n.id
+        JOIN sentiment s ON ns.sentiment_id = s.id
+        GROUP BY s.candidate_id, n.media_id
+        """), on: cawagub_sentiments.candidate_id == p.cawagub_id and cawagub_sentiments.media_id == ^id,
+      select: %{
+        pairing: %{p |
+          sentiments: %{
+            cagub: %{
+              positive: cagub_sentiments.positive,
+              neutral: cagub_sentiments.neutral,
+              negative: cagub_sentiments.negative,
+            },
+            cawagub: %{
+              positive: cawagub_sentiments.positive,
+              neutral: cawagub_sentiments.neutral,
+              negative: cawagub_sentiments.negative,
+            },
+          },
+        },
+        candidates: %{
+          cagub: %{cagub |
+            sentiments: %{
+              positive: cagub_sentiments.positive,
+              neutral: cagub_sentiments.neutral,
+              negative: cagub_sentiments.negative,
+            },
+          },
+          cawagub: %{cawagub |
+            sentiments: %{
+              positive: cawagub_sentiments.positive,
+              neutral: cawagub_sentiments.neutral,
+              negative: cawagub_sentiments.negative,
+            },
+          },
+        },
+      }
+
+    query
+    |> Repo.all
+  end
+
 end

--- a/rojak-api/web/models/media.ex
+++ b/rojak-api/web/models/media.ex
@@ -12,6 +12,9 @@ defmodule RojakAPI.Media do
     field :twitter_username, :string
     field :instagram_username, :string
 
+    # Virtual fields for embedding joins
+    field :sentiments, :map, virtual: true
+
     # Relationship
     has_many :news, RojakAPI.News
 

--- a/rojak-api/web/models/news.ex
+++ b/rojak-api/web/models/news.ex
@@ -51,11 +51,11 @@ defmodule RojakAPI.News do
   defp fetch_embed(query, embed) when is_nil(embed), do: query
   defp fetch_embed(query, embed) do
     query
-    |> fetch_mentions(Enum.member?(embed, "mentions"))
+    |> fetch_sentiments(Enum.member?(embed, "sentiments"))
   end
 
-  defp fetch_mentions(query, embed?) when not embed?, do: query
-  defp fetch_mentions(query, _) do
+  defp fetch_sentiments(query, embed?) when not embed?, do: query
+  defp fetch_sentiments(query, _) do
     from q in query,
       join: ns in assoc(q, :sentiments),
       join: s in assoc(ns, :sentiment),

--- a/rojak-api/web/models/news.ex
+++ b/rojak-api/web/models/news.ex
@@ -57,8 +57,10 @@ defmodule RojakAPI.News do
   defp fetch_mentions(query, embed?) when not embed?, do: query
   defp fetch_mentions(query, _) do
     from q in query,
-      join: m in assoc(q, :mentions),
-      preload: [mentions: m]
+      join: ns in assoc(q, :sentiments),
+      join: s in assoc(ns, :sentiment),
+      join: c in assoc(s, :candidate),
+      preload: [sentiments: {ns, sentiment: {s, candidate: c}}]
   end
 
 end

--- a/rojak-api/web/router.ex
+++ b/rojak-api/web/router.ex
@@ -19,6 +19,7 @@ defmodule RojakAPI.Router do
       get "/news/:id", NewsController, :show
       get "/media", MediaController, :index
       get "/media/:id", MediaController, :show
+      get "/media/:id/sentiments", MediaController, :sentiments
     end
   end
 end

--- a/rojak-api/web/router.ex
+++ b/rojak-api/web/router.ex
@@ -15,6 +15,7 @@ defmodule RojakAPI.Router do
       get "/pairings/:id", PairingController, :show
       get "/candidates", CandidateController, :index
       get "/candidates/:id", CandidateController, :show
+      get "/candidates/:id/media-sentiments", CandidateController, :media_sentiments
       get "/news", NewsController, :index
       get "/news/:id", NewsController, :show
       get "/media", MediaController, :index

--- a/rojak-api/web/router.ex
+++ b/rojak-api/web/router.ex
@@ -13,6 +13,7 @@ defmodule RojakAPI.Router do
     scope "/v1", V1, as: :v1 do
       get "/pairings", PairingController, :index
       get "/pairings/:id", PairingController, :show
+      get "/pairings/:id/media-sentiments", PairingController, :media_sentiments
       get "/candidates", CandidateController, :index
       get "/candidates/:id", CandidateController, :show
       get "/candidates/:id/media-sentiments", CandidateController, :media_sentiments

--- a/rojak-api/web/v1/candidate/candidate_controller.ex
+++ b/rojak-api/web/v1/candidate/candidate_controller.ex
@@ -4,7 +4,7 @@ defmodule RojakAPI.V1.CandidateController do
   alias RojakAPI.Candidate
 
   @apidoc """
-    @api {get} /candidates Get Candidates 
+    @api {get} /candidates Get Candidates
     @apiGroup Candidates
     @apiName GetCandidates
     @apiVersion 1.0.0
@@ -119,8 +119,8 @@ defmodule RojakAPI.V1.CandidateController do
       }
     @apiErrorExample {json} Item Not Found
       HTTP/1.1 404 Not Found
-      { 
-        "message" : "item not found" 
+      {
+        "message" : "item not found"
       }
   """
   defparams candidate_show_params(%{
@@ -171,5 +171,17 @@ defmodule RojakAPI.V1.CandidateController do
         }
       ]
   """
+  defparams candidate_media_sentiments_params %{
+    id!: :integer,
+    limit: [field: :integer, default: 10],
+    offset: [field: :integer, default: 0],
+  }
+
+  def media_sentiments(conn, params) do
+    validated_params = ParamsValidator.validate params, &candidate_media_sentiments_params/1
+    media_sentiments = Candidate.fetch_media_sentiments(validated_params)
+    render(conn, "media_sentiments.json", media_sentiments: media_sentiments)
+  end
+
 
 end

--- a/rojak-api/web/v1/candidate/candidate_controller.ex
+++ b/rojak-api/web/v1/candidate/candidate_controller.ex
@@ -183,5 +183,4 @@ defmodule RojakAPI.V1.CandidateController do
     render(conn, "media_sentiments.json", media_sentiments: media_sentiments)
   end
 
-
 end

--- a/rojak-api/web/v1/candidate/candidate_view.ex
+++ b/rojak-api/web/v1/candidate/candidate_view.ex
@@ -12,7 +12,7 @@ defmodule RojakAPI.V1.CandidateView do
   def render("candidate.json", %{candidate: candidate}) do
     candidate =
       candidate
-      |> Map.drop([:__meta__, :mentioned_in, :sentiments])
+      |> Map.drop([:__meta__, :mentioned_in])
 
     # Embed pairing
     candidate = case Map.get(candidate, :pairing) do
@@ -21,6 +21,20 @@ defmodule RojakAPI.V1.CandidateView do
       pairing ->
         Map.update! candidate, :pairing, fn _ ->
           Map.drop(pairing, [:__meta__, :cagub, :cawagub])
+        end
+    end
+
+    # Embed sentiments
+    candidate = case Map.get(candidate, :sentiments) do
+      nil ->
+        candidate |> Map.drop([:sentiments])
+      sentiments ->
+        Map.update! candidate, :sentiments, fn _ ->
+            %{
+              positive: sentiments.positive,
+              neutral: sentiments.neutral,
+              negative: sentiments.negative,
+            }
         end
     end
 

--- a/rojak-api/web/v1/candidate/candidate_view.ex
+++ b/rojak-api/web/v1/candidate/candidate_view.ex
@@ -9,6 +9,10 @@ defmodule RojakAPI.V1.CandidateView do
     render_one(candidate, RojakAPI.V1.CandidateView, "candidate.json")
   end
 
+  def render("media_sentiments.json", %{media_sentiments: media_sentiments}) do
+    render_many(media_sentiments, RojakAPI.V1.CandidateView, "media_sentiment.json", as: :media_sentiment)
+  end
+
   def render("candidate.json", %{candidate: candidate}) do
     candidate =
       candidate
@@ -40,4 +44,10 @@ defmodule RojakAPI.V1.CandidateView do
 
     candidate
   end
+
+  def render("media_sentiment.json", %{media_sentiment: media_sentiment}) do
+    media_sentiment
+    |> Map.drop([:__meta__, :news])
+  end
+
 end

--- a/rojak-api/web/v1/media/media_controller.ex
+++ b/rojak-api/web/v1/media/media_controller.ex
@@ -4,7 +4,7 @@ defmodule RojakAPI.V1.MediaController do
   alias RojakAPI.Media
 
   @apidoc """
-    @api {get} /media Get Media 
+    @api {get} /media Get Media
     @apiGroup Media
     @apiName GetMedia
     @apiVersion 1.0.0
@@ -62,8 +62,8 @@ defmodule RojakAPI.V1.MediaController do
       }
     @apiErrorExample {json} Item Not Found
       HTTP/1.1 404 Not Found
-      { 
-        "message" : "item not found" 
+      {
+        "message" : "item not found"
       }
   """
   defparams media_show_params %{
@@ -152,5 +152,14 @@ defmodule RojakAPI.V1.MediaController do
         }
       ]
   """
+  defparams media_sentiments_params %{
+    id!: :integer,
+  }
+
+  def sentiments(conn, params) do
+    validated_params = ParamsValidator.validate params, &media_sentiments_params/1
+    sentiments = Media.fetch_sentiments(validated_params)
+    render(conn, "sentiments.json", sentiments: sentiments)
+  end
 
 end

--- a/rojak-api/web/v1/media/media_view.ex
+++ b/rojak-api/web/v1/media/media_view.ex
@@ -9,7 +9,21 @@ defmodule RojakAPI.V1.MediaView do
     render_one(media, RojakAPI.V1.MediaView, "media.json")
   end
 
+  def render("sentiments.json", %{sentiments: sentiments}) do
+    render_many(sentiments, RojakAPI.V1.MediaView, "sentiment.json", as: :sentiment)
+  end
+
   def render("media.json", %{media: media}) do
     Map.drop media, [:__meta__, :news]
+  end
+
+  def render("sentiment.json", %{sentiment: sentiment}) do
+    %{sentiment |
+      pairing: Map.drop(sentiment.pairing, [:__meta__, :cagub, :cawagub, :candidates]),
+      candidates: %{sentiment.candidates |
+        cagub: Map.drop(sentiment.candidates.cagub, [:__meta__, :mentioned_in]),
+        cawagub: Map.drop(sentiment.candidates.cawagub, [:__meta__, :mentioned_in]),
+      }
+    }
   end
 end

--- a/rojak-api/web/v1/media/media_view.ex
+++ b/rojak-api/web/v1/media/media_view.ex
@@ -14,7 +14,7 @@ defmodule RojakAPI.V1.MediaView do
   end
 
   def render("media.json", %{media: media}) do
-    Map.drop media, [:__meta__, :news]
+    Map.drop media, [:__meta__, :news, :sentiments]
   end
 
   def render("sentiment.json", %{sentiment: sentiment}) do

--- a/rojak-api/web/v1/news/news_controller.ex
+++ b/rojak-api/web/v1/news/news_controller.ex
@@ -4,7 +4,7 @@ defmodule RojakAPI.V1.NewsController do
   alias RojakAPI.News
 
   @apidoc """
-    @api {get} /news Get News 
+    @api {get} /news Get News
     @apiGroup News
     @apiName GetNews
     @apiVersion 1.0.0
@@ -30,7 +30,7 @@ defmodule RojakAPI.V1.NewsController do
           "author_name": "Anto",
           "inserted_at": 1341533193,
           "updated_at": 1341533193,
-          "mentions": 
+          "mentions":
           [
             {
               "id": 1,
@@ -61,7 +61,7 @@ defmodule RojakAPI.V1.NewsController do
           "author_name": "Anto",
           "inserted_at": 1341533201,
           "updated_at": 1341533201,
-          "mentions": 
+          "mentions":
           [
             {
               "id": 1,
@@ -124,7 +124,7 @@ defmodule RojakAPI.V1.NewsController do
         "author_name": "Anto",
         "inserted_at": 1341533193,
         "updated_at": 1341533193,
-        "mentions": 
+        "mentions":
         [
           {
             "id": 1,
@@ -149,7 +149,7 @@ defmodule RojakAPI.V1.NewsController do
       }
     @apiErrorExample {json} Item Not Found
       HTTP/1.1 404 Not Found
-      { 
+      {
         "message" : "item not found"
       }
   """

--- a/rojak-api/web/v1/news/news_controller.ex
+++ b/rojak-api/web/v1/news/news_controller.ex
@@ -61,8 +61,7 @@ defmodule RojakAPI.V1.NewsController do
           "author_name": "Anto",
           "inserted_at": 1341533201,
           "updated_at": 1341533201,
-          "mentions":
-          [
+          "sentiments": [
             {
               "id": 1,
               "full_name": "Basuki Tjahaja Purnama",
@@ -95,7 +94,7 @@ defmodule RojakAPI.V1.NewsController do
   }) do
     def changeset(ch, params) do
       cast(ch, params, [:limit, :offset, :embed, :media_id, :candidate_id])
-      |> validate_subset(:embed, ["mentions"])
+      |> validate_subset(:embed, ["sentiments"])
     end
   end
 
@@ -111,7 +110,7 @@ defmodule RojakAPI.V1.NewsController do
     @apiName GetANews
     @apiVersion 1.0.0
     @apiParam {String} newsId
-    @apiParam {String} [embed[]] Fields to embed on the response. Available fields: <code>mentions</code> </br></br> Example:
+    @apiParam {String} [embed[]] Fields to embed on the response. Available fields: <code>sentiments</code> </br></br> Example:
       <pre>?embed[]=field1&embed[]=field2</pre>
     @apiDescription Get a news article based on {newsId}, optionally with mentioned candidates.
     @apiSuccessExample {json} Success
@@ -124,8 +123,7 @@ defmodule RojakAPI.V1.NewsController do
         "author_name": "Anto",
         "inserted_at": 1341533193,
         "updated_at": 1341533193,
-        "mentions":
-        [
+        "sentiments": [
           {
             "id": 1,
             "full_name": "Basuki Tjahaja Purnama",
@@ -159,7 +157,7 @@ defmodule RojakAPI.V1.NewsController do
   }) do
     def changeset(ch, params) do
       cast(ch, params, [:id, :embed])
-      |> validate_subset(:embed, ["mentions"])
+      |> validate_subset(:embed, ["sentiments"])
     end
   end
 

--- a/rojak-api/web/v1/news/news_view.ex
+++ b/rojak-api/web/v1/news/news_view.ex
@@ -12,18 +12,45 @@ defmodule RojakAPI.V1.NewsView do
   def render("news.json", %{news: news}) do
     news =
       news
-      |> Map.drop([:__meta__, :media, :sentiments, :mentioned_candidates])
+      |> Map.drop([:__meta__, :media, :mentions])
+
+    sentiments = Map.get(news, :sentiments)
+
+    news =
+      news
+      |> Map.drop([:sentiments])
 
     # Embed mentions
-    news = case Map.get(news, :mentions) do
+    news = case sentiments do
       %Ecto.Association.NotLoaded{} ->
-        news |> Map.drop([:mentions])
-      mentions ->
-        Map.update! news, :mentions, fn _ ->
-          Enum.map mentions, fn mention ->
-            Map.drop(mention, [:__meta__, :mentioned_in, :sentiments])
+        news
+      _ ->
+        mentions =
+          Enum.map sentiments, fn news_sentiment ->
+            candidate =
+              news_sentiment
+              |> Map.get(:sentiment)
+              |> Map.get(:candidate)
+              |> Map.drop([:__meta__, :mentioned_in, :pairing, :sentiments])
+            sentiment_name =
+              news_sentiment
+              |> Map.get(:sentiment)
+              |> Map.get(:name)
+            sentiment_type = case sentiment_name do
+              "pro" <> _ -> "positive"
+              "net" <> _ -> "neutral"
+              "con" <> _ -> "negative"
+            end
+            score =
+              news_sentiment
+              |> Map.get(:score)
+            Map.put candidate, :sentiment, %{
+              type: sentiment_type,
+              score: score
+            }
           end
-        end
+
+        Map.put news, :mentions, mentions
     end
 
     news

--- a/rojak-api/web/v1/news/news_view.ex
+++ b/rojak-api/web/v1/news/news_view.ex
@@ -25,7 +25,7 @@ defmodule RojakAPI.V1.NewsView do
       %Ecto.Association.NotLoaded{} ->
         news
       _ ->
-        mentions =
+        sentiments =
           Enum.map sentiments, fn news_sentiment ->
             candidate =
               news_sentiment
@@ -50,7 +50,7 @@ defmodule RojakAPI.V1.NewsView do
             }
           end
 
-        Map.put news, :mentions, mentions
+        Map.put news, :sentiments, sentiments
     end
 
     news

--- a/rojak-api/web/v1/pairing/pairing_controller.ex
+++ b/rojak-api/web/v1/pairing/pairing_controller.ex
@@ -3,8 +3,6 @@ defmodule RojakAPI.V1.PairingController do
 
   alias RojakAPI.PairOfCandidates
 
-  # TODO: also load sentiments and candidates if `embed` parameter is set
-
   @apidoc """
     @api {get} /pairings Get Pairs
     @apiGroup Pairings
@@ -138,8 +136,8 @@ defmodule RojakAPI.V1.PairingController do
       }
     @apiErrorExample {json} Item Not Found
       HTTP/1.1 404 Not Found
-      { 
-        "message" : "item not found" 
+      {
+        "message" : "item not found"
       }
   """
   defparams pairing_show_params(%{
@@ -190,5 +188,16 @@ defmodule RojakAPI.V1.PairingController do
         }
       ]
   """
+  defparams pairing_media_sentiments_params %{
+    id!: :integer,
+    limit: [field: :integer, default: 10],
+    offset: [field: :integer, default: 0],
+  }
+
+  def media_sentiments(conn, params) do
+    validated_params = ParamsValidator.validate params, &pairing_media_sentiments_params/1
+    media_sentiments = PairOfCandidates.fetch_media_sentiments(validated_params)
+    render(conn, "media_sentiments.json", media_sentiments: media_sentiments)
+  end
 
 end

--- a/rojak-api/web/v1/pairing/pairing_view.ex
+++ b/rojak-api/web/v1/pairing/pairing_view.ex
@@ -27,6 +27,14 @@ defmodule RojakAPI.V1.PairingView do
         end
     end
 
+    # Embed sentiments
+    pairing = case Map.get(pairing, :sentiments) do
+      nil ->
+        pairing |> Map.drop([:sentiments])
+      _ ->
+        pairing
+    end
+
     pairing
   end
 end

--- a/rojak-api/web/v1/pairing/pairing_view.ex
+++ b/rojak-api/web/v1/pairing/pairing_view.ex
@@ -9,6 +9,10 @@ defmodule RojakAPI.V1.PairingView do
     render_one(pairing, RojakAPI.V1.PairingView, "pairing.json")
   end
 
+  def render("media_sentiments.json", %{media_sentiments: media_sentiments}) do
+    render_many(media_sentiments, RojakAPI.V1.PairingView, "media_sentiment.json", as: :media_sentiment)
+  end
+
   def render("pairing.json", %{pairing: pairing}) do
     pairing =
       pairing
@@ -37,4 +41,10 @@ defmodule RojakAPI.V1.PairingView do
 
     pairing
   end
+
+  def render("media_sentiment.json", %{media_sentiment: media_sentiment}) do
+    media_sentiment
+    |> Map.drop([:__meta__, :news])
+  end
+
 end


### PR DESCRIPTION
PR ini menambahkan fungsionalitas embedding dan fetching sentiment dari #132.

Sambil menunggu #126 dan #138, di sini ada beberapa poin yang agak berbeda dengan spesifikasi v0.2, yaitu:
1. Sentimen saat ini berupa **banyaknya berita positif/netral/negatif terhadap suatu kandidat**, diperoleh dari counting pada table `news_sentiment`.
2. Untuk sentimen yang berhubungan dengan pasangan kandidat, saat ini memiliki perbedaan format:
   
   ``` json
   // spec
   {
     "sentiments": {
       "positive": 123,
       "neutral": 123,
       "negative": 123
     }
   }
   
   // current
   {
     "sentiments": {
       "cagub": {
         "positive": 123,
         "neutral": 123,
         "negative": 123
       },
       "cawagub": {
         "positive": 123,
         "neutral": 123,
         "negative": 123
       }
     }
   }
   ```
   
   Dapat dilihat bahwa kita dipisahkan jadi masing-masing cagub dan cawagub. Ini dilakukan karena saya masih agak bingung gimana ideal untuk agregasinya (ditambahkan saja kah? Gimana kalau satu berita menyebut cagub dan cawagubnya?), dan juga masih tergantung pada bentuk akhir scoring sentiment yang ingin didapatkan (#138).

Pada PR ini, semua endpoint yang ada pada spesifikasi sudah aktif.

Note: Ecto (ORM dari Elixir) agak kaku untuk ngebuat complex SQL query, jadi di beberapa tempat saya ada yang pakai raw SQL query melalui `fragment`. Harusnya ga perlu khawatir SQL injection sih karena udah dihandle sama Ecto-nya.
